### PR TITLE
fix(security): sanitize markdown rendering and issue body inputs (P0 XSS)

### DIFF
--- a/apps/octocat-blog-app/app/post/[slug]/page.tsx
+++ b/apps/octocat-blog-app/app/post/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { format } from "date-fns";
 import { ArrowLeft, Calendar, Clock } from "lucide-react";
 import { CategoryBadge } from "@/components/category-badge";
 import { AuthorCard } from "@/components/author-card";
+import { renderMarkdown } from "@/lib/markdown";
 import type { Metadata } from "next";
 
 interface PostPageProps {
@@ -148,7 +149,7 @@ export default async function PostPage({ params }: PostPageProps) {
         {/* Parse markdown content */}
         <div
           dangerouslySetInnerHTML={{
-            __html: parseMarkdown(post.content),
+            __html: renderMarkdown(post.content),
           }}
         />
       </div>
@@ -198,39 +199,4 @@ export default async function PostPage({ params }: PostPageProps) {
   );
 }
 
-// Simple markdown parser for basic formatting
-function parseMarkdown(content: string): string {
-  return (
-    content
-      // Code blocks
-      .replace(
-        /```(\w+)?\n([\s\S]*?)```/g,
-        '<pre><code class="language-$1">$2</code></pre>'
-      )
-      // Inline code
-      .replace(/`([^`]+)`/g, "<code>$1</code>")
-      // Headers
-      .replace(/^### (.*$)/gim, "<h3>$1</h3>")
-      .replace(/^## (.*$)/gim, "<h2>$1</h2>")
-      .replace(/^# (.*$)/gim, "<h1>$1</h1>")
-      // Bold
-      .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
-      // Italic
-      .replace(/\*(.*?)\*/g, "<em>$1</em>")
-      // Links
-      .replace(
-        /\[([^\]]+)\]\(([^)]+)\)/g,
-        '<a href="$2" class="text-primary hover:underline">$1</a>'
-      )
-      // Unordered lists
-      .replace(/^- (.*$)/gim, "<li>$1</li>")
-      // Ordered lists
-      .replace(/^\d+\. (.*$)/gim, "<li>$1</li>")
-      // Horizontal rule
-      .replace(/^---$/gim, "<hr>")
-      // Paragraphs
-      .replace(/\n\n/g, "</p><p>")
-      // Line breaks
-      .replace(/\n/g, "<br>")
-  );
-}
+

--- a/apps/octocat-blog-app/config/jest/jest.config.js
+++ b/apps/octocat-blog-app/config/jest/jest.config.js
@@ -1,4 +1,4 @@
-const esmModules = ["uuid"];
+const esmModules = ["uuid", "marked"];
 
 module.exports = {
   rootDir: "../../",

--- a/apps/octocat-blog-app/lib/__tests__/markdown.test.ts
+++ b/apps/octocat-blog-app/lib/__tests__/markdown.test.ts
@@ -1,0 +1,105 @@
+import { renderMarkdown } from "@/lib/markdown";
+
+describe("renderMarkdown", () => {
+  describe("safe formatting", () => {
+    it("renders bold text", () => {
+      expect(renderMarkdown("**bold**")).toContain("<strong>bold</strong>");
+    });
+
+    it("renders italics", () => {
+      expect(renderMarkdown("*italic*")).toContain("<em>italic</em>");
+    });
+
+    it("renders headings", () => {
+      const html = renderMarkdown("# Title");
+      expect(html).toContain("<h1>Title</h1>");
+    });
+
+    it("renders inline code", () => {
+      expect(renderMarkdown("Use `npm` here")).toContain("<code>npm</code>");
+    });
+
+    it("renders code blocks", () => {
+      const html = renderMarkdown("```\nconst x = 1;\n```");
+      expect(html).toContain("<pre>");
+      expect(html).toContain("const x = 1;");
+    });
+
+    it("renders links with safe attributes", () => {
+      const html = renderMarkdown("[GitHub](https://github.com)");
+      expect(html).toContain('href="https://github.com"');
+      expect(html).toContain("GitHub");
+    });
+
+    it("renders unordered lists", () => {
+      const html = renderMarkdown("- one\n- two");
+      expect(html).toContain("<ul>");
+      expect(html).toContain("<li>one</li>");
+      expect(html).toContain("<li>two</li>");
+    });
+
+    it("renders empty input as empty string", () => {
+      expect(renderMarkdown("")).toBe("");
+    });
+  });
+
+  describe("XSS protection", () => {
+    it("strips inline <script> tags", () => {
+      const html = renderMarkdown("<script>alert('xss')</script>");
+      expect(html).not.toContain("<script>");
+      expect(html).not.toContain("alert(");
+    });
+
+    it("strips <script> tags inside markdown content", () => {
+      const html = renderMarkdown("Hello <script>alert(1)</script> world");
+      expect(html).not.toContain("<script>");
+      expect(html).not.toContain("alert(1)");
+    });
+
+    it("strips javascript: links", () => {
+      const html = renderMarkdown("[click](javascript:alert('xss'))");
+      expect(html).not.toMatch(/href\s*=\s*["']?\s*javascript:/i);
+    });
+
+    it("strips onerror attribute on img", () => {
+      const html = renderMarkdown(
+        '<img src="x" onerror="alert(\'xss\')" />'
+      );
+      expect(html).not.toContain("onerror");
+      expect(html).not.toContain("alert(");
+    });
+
+    it("strips iframe tags", () => {
+      const html = renderMarkdown(
+        '<iframe src="https://evil.example"></iframe>'
+      );
+      expect(html).not.toContain("<iframe");
+    });
+
+    it("strips style tags", () => {
+      const html = renderMarkdown(
+        "<style>body { background: url('javascript:alert(1)') }</style>"
+      );
+      expect(html).not.toContain("<style");
+    });
+
+    it("strips inline event handlers in HTML", () => {
+      const html = renderMarkdown('<a href="#" onclick="steal()">x</a>');
+      expect(html).not.toContain("onclick");
+    });
+
+    it("strips data: URI scripts", () => {
+      const html = renderMarkdown(
+        "[click](data:text/html,<script>alert('xss')</script>)"
+      );
+      expect(html).not.toContain("<script>");
+    });
+
+    it("strips form tags", () => {
+      const html = renderMarkdown(
+        '<form action="https://evil.example"><input /></form>'
+      );
+      expect(html).not.toContain("<form");
+    });
+  });
+});

--- a/apps/octocat-blog-app/lib/markdown.ts
+++ b/apps/octocat-blog-app/lib/markdown.ts
@@ -1,0 +1,62 @@
+import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
+
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "br",
+    "hr",
+    "strong",
+    "em",
+    "del",
+    "code",
+    "pre",
+    "blockquote",
+    "ul",
+    "ol",
+    "li",
+    "a",
+    "img",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+  ],
+  allowedAttributes: {
+    a: ["href", "title", "target", "rel"],
+    img: ["src", "alt", "title"],
+    "*": ["class", "id"],
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+  allowedSchemesAppliedToAttributes: ["href", "src"],
+  disallowedTagsMode: "discard",
+};
+
+/**
+ * Renders untrusted markdown content to a safe HTML string.
+ *
+ * Uses `marked` for parsing and `sanitize-html` (pure JS, SSR-safe) for
+ * sanitization, stripping any embedded scripts, event handlers, and
+ * dangerous URL schemes. Safe to embed via `dangerouslySetInnerHTML` in a
+ * Server Component.
+ */
+export function renderMarkdown(content: string): string {
+  if (!content) return "";
+
+  const rawHtml = marked.parse(content, { async: false }) as string;
+
+  return sanitizeHtml(rawHtml, SANITIZE_OPTIONS);
+}

--- a/apps/octocat-blog-app/package.json
+++ b/apps/octocat-blog-app/package.json
@@ -27,11 +27,13 @@
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.38.0",
     "lucide-react": "^0.475.0",
+    "marked": "^18.0.3",
     "next": "15.5.15",
     "next-themes": "^0.4.6",
     "pg": "^8.13.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "sanitize-html": "^2.17.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -46,6 +48,7 @@
     "@types/pg": "^8.11.10",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
+    "@types/sanitize-html": "^2.16.1",
     "@workspace/eslint-config": "workspace:^",
     "@workspace/typescript-config": "workspace:*",
     "dotenv": "^16.4.5",

--- a/apps/octocat-support-app/lib/direct-triage.ts
+++ b/apps/octocat-support-app/lib/direct-triage.ts
@@ -1,4 +1,5 @@
 import type { TicketFormData, TicketResponse } from "@/lib/types";
+import { escapeMarkdown } from "@/lib/escape";
 
 interface GitHubConfig {
   token: string;
@@ -32,7 +33,11 @@ const CATEGORY_PREFIX: Record<string, string> = {
  * Generates a structured issue body based on ticket category.
  */
 function generateIssueBody(ticket: TicketFormData): string {
-  const { category, name, email, subject, description } = ticket;
+  const { category, description } = ticket;
+  const name = escapeMarkdown(ticket.name);
+  const email = escapeMarkdown(ticket.email);
+  const subject = escapeMarkdown(ticket.subject);
+  const priority = escapeMarkdown(ticket.priority);
 
   switch (category) {
     case "bug":
@@ -84,7 +89,7 @@ function generateIssueBody(ticket: TicketFormData): string {
         description,
         "",
         "## Severity Assessment",
-        `Priority: ${ticket.priority}`,
+        `Priority: ${priority}`,
         "",
         "## Reporter",
         `- **Name:** ${name}`,

--- a/apps/octocat-support-app/lib/escape.ts
+++ b/apps/octocat-support-app/lib/escape.ts
@@ -1,0 +1,41 @@
+/**
+ * Escapes a string for safe interpolation into Markdown content.
+ *
+ * Strips newlines and escapes characters that have semantic meaning in
+ * Markdown or HTML. Use this on any user-supplied field before embedding it
+ * in a GitHub issue body or other Markdown-rendered context to prevent
+ * injection attacks (e.g. fake heading rows, embedded HTML, malicious links).
+ *
+ * Note: This is intentionally aggressive — fields treated as plain identifiers
+ * (name, email, subject, priority) should never need formatting. For
+ * fields where users may legitimately use markdown (e.g. description), do
+ * not apply this helper; rely on GitHub's own renderer + sandboxed display.
+ */
+export function escapeMarkdown(input: string | null | undefined): string {
+  if (input == null) return "";
+
+  const stringified = String(input);
+
+  return stringified
+    .replace(/[\r\n]+/g, " ")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/\{/g, "\\{")
+    .replace(/\}/g, "\\}")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/#/g, "\\#")
+    .replace(/\+/g, "\\+")
+    .replace(/-/g, "\\-")
+    .replace(/\./g, "\\.")
+    .replace(/!/g, "\\!")
+    .replace(/\|/g, "\\|")
+    .trim();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
+      marked:
+        specifier: ^18.0.3
+        version: 18.0.3
       next:
         specifier: 15.5.15
         version: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -132,6 +135,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      sanitize-html:
+        specifier: ^2.17.3
+        version: 2.17.3
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -169,6 +175,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@workspace/eslint-config':
         specifier: workspace:^
         version: link:../../packages/eslint-config
@@ -3315,6 +3324,9 @@ packages:
   '@types/react@19.1.9':
     resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -4412,6 +4424,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4893,6 +4909,9 @@ packages:
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -5083,6 +5102,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5558,6 +5581,11 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  marked@18.0.3:
+    resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -5863,6 +5891,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -6238,6 +6269,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.3:
+    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
 
   sax@1.4.3:
     resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
@@ -6820,6 +6854,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10049,6 +10084,10 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -11071,6 +11110,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-paths@3.0.0: {}
 
   error-ex@1.3.4:
@@ -11848,6 +11889,13 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -12073,6 +12121,8 @@ snapshots:
   is-path-cwd@2.2.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -12869,6 +12919,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  marked@18.0.3: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
@@ -13194,6 +13246,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-srcset@1.0.2: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -13642,6 +13696,15 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.3:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   sax@1.4.3: {}
 


### PR DESCRIPTION
## Summary

Phase 3 of the repo triage plan — fixes the two P0 XSS issues in the security baseline milestone.

## Closes
- Closes #220 — XSS in blog markdown rendering
- Closes #224 — Unsanitized user input in support-app issue body

## Changes

### Blog markdown (`apps/octocat-blog-app`)
- New `lib/markdown.ts` exporting `renderMarkdown(content: string): string`, built on `marked` (parsing) + `sanitize-html` (sanitization). Pure JS, SSR-safe (no jsdom).
- `app/post/[slug]/page.tsx` swaps the inline regex parser (lines 202-236) for `renderMarkdown(...)`.
- Allowlist: standard formatting, code/pre, blockquote, lists, tables, anchors, images. Schemes limited to http/https/mailto. Disallowed-tag mode: `discard`.
- 17-test XSS regression suite under `lib/__tests__/markdown.test.ts` covering safe formatting and known payloads (`<script>`, `javascript:` href, `<img onerror>`, iframe/style/form, `data:` URI). 100% line/branch coverage on the renderer.

### Support-app issue body (`apps/octocat-support-app`)
- New `lib/escape.ts` exporting `escapeMarkdown(value)` — HTML-entity-escapes the value and strips markdown control characters + newlines.
- `lib/direct-triage.ts` applies `escapeMarkdown` to `name`, `email`, `subject`, and `priority` in `generateIssueBody`.
- `description` intentionally left raw: users may legitimately use markdown formatting, and GitHub renders user-supplied issue bodies with its own sandboxed renderer.

## Notes
- Why `sanitize-html` instead of DOMPurify? `isomorphic-dompurify` pulls in jsdom, which references `default-stylesheet.css` at runtime and breaks Next.js SSR (ENOENT during prerender). `sanitize-html` is pure JS, depends on `htmlparser2`, and works cleanly in both Server Components and Node.

## Verification
- Blog markdown tests: 17/17 pass, 100% coverage
- Blog lint: 0 errors (only pre-existing warnings)
- Support-app build: ✅ green

## Plan progress
| Phase | PR | Status |
|---|---|---|
| 1 — repo hygiene | #283 | ✅ open |
| 2 — packaging foundation | #285 | ✅ open |
| **3 — XSS + sanitization** | **this PR** | ✅ |
| 4 — auth | TBD | ⏳ |
| 5 — rate limiting | TBD | ⏳ |
| 6 — CI fixes | TBD | ⏳ |
| 7 — testing baselines | TBD | ⏳ |
| 8 — wrap-up + branch cleanup | TBD (needs user approval) | ⏳ |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>