### PR TITLE
fix(ci): add support-app workflows + make Azure security gate blocking

### DIFF
--- a/.github/workflows/octocat-support-app-build.yml
+++ b/.github/workflows/octocat-support-app-build.yml
@@ -1,0 +1,56 @@
+name: Octocat Support App Build
+
+on:
+  pull_request:
+    branches: ["main", "develop/**"]
+    paths:
+      - "apps/octocat-support-app/**"
+      - "packages/ui/**"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Next.js Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.11]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Disable Corepack
+        run: corepack disable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build (with placeholder env)
+        env:
+          # The support app reads these at build time for direct-triage.
+          # Real values are injected at deploy; placeholders here are
+          # only used to satisfy build-time validation.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_OWNER: placeholder-owner
+          GITHUB_REPO: placeholder-repo
+        run: |
+          cd apps/octocat-support-app
+          pnpm build

--- a/.github/workflows/octocat-support-app-lint.yml
+++ b/.github/workflows/octocat-support-app-lint.yml
@@ -1,0 +1,50 @@
+name: Octocat Support App Lint
+
+on:
+  pull_request:
+    branches: ["main", "develop/**"]
+    paths:
+      - "apps/octocat-support-app/**"
+      - "packages/ui/**"
+      - "packages/eslint-config/**"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.11]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Disable Corepack
+        run: corepack disable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run linting
+        run: |
+          cd apps/octocat-support-app
+          pnpm lint

--- a/.github/workflows/octocat-support-app-typecheck.yml
+++ b/.github/workflows/octocat-support-app-typecheck.yml
@@ -1,0 +1,50 @@
+name: Octocat Support App Type Check
+
+on:
+  pull_request:
+    branches: ["main", "develop/**"]
+    paths:
+      - "apps/octocat-support-app/**"
+      - "packages/ui/**"
+      - "packages/typescript-config/**"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: TypeScript Type Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.11]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Disable Corepack
+        run: corepack disable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run type check
+        run: |
+          cd apps/octocat-support-app
+          pnpm typecheck

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,4 +102,9 @@ stages:
 
           - script: pnpm audit --audit-level=high
             displayName: "Audit dependencies"
-            continueOnError: true
+            # Fail the build on high+ severity vulnerabilities. Previously
+            # `continueOnError: true` silently masked findings — see #234.
+            # Use `pnpm audit --audit-level=critical` if temporary noise
+            # blocks merges, but never restore continueOnError.
+            continueOnError: false
+


### PR DESCRIPTION
## Phase 6 — P1 CI fixes

Closes #233 (P1 CI-1 — Add CI workflow for octocat-support-app)
Closes #234 (P1 CI-2 — Azure Pipeline security scan silently ignores failures)

### What changed

**Three new GitHub Actions workflows for `apps/octocat-support-app`:**
- `octocat-support-app-lint.yml` — runs `pnpm lint` (Next.js ESLint)
- `octocat-support-app-typecheck.yml` — runs `pnpm typecheck` (`tsc --noEmit`)
- `octocat-support-app-build.yml` — runs `pnpm build` with placeholder env vars

All three mirror the existing `octocat-blog-app-*.yml` pattern:
- Pinned actions (`actions/checkout@v6`, `pnpm/action-setup@v5`, `actions/setup-node@v6`)
- Least-privilege `permissions: contents: read`
- `concurrency` block with `cancel-in-progress: true`
- Granular `paths` filters so only relevant changes trigger them
- Node 22.11 matrix (consistent with blog-app)

**`azure-pipelines.yml` audit step is now a real gate:**
- Removed `continueOnError: true` from the `pnpm audit --audit-level=high` step
- Added an inline comment so future contributors don't reintroduce silent-pass behavior
- The threshold (`--audit-level=high`) was already sensible — it won't fail on low/moderate findings

### What's NOT in this PR

A unit-tests workflow for the support-app is **deferred to Phase 7b (issue #227)** because the app currently has no `test` script in `package.json`. The build workflow exercises the same code paths in the meantime.

### Verification

- `cd apps/octocat-support-app && pnpm lint` — passes (warnings only, no errors)
- `cd apps/octocat-support-app && pnpm typecheck` — passes
- All four YAML files validated with `yaml.safe_load` locally

### Heads-up for reviewers

The `pnpm audit` gate may surface findings on the next push. The remote already reports 77 vulnerabilities on the default branch (3 critical / 42 high / 26 moderate / 6 low) — those are mostly transitive deps that Dependabot is already chasing in the open PRs from Phase 0 triage. If the gate becomes too noisy in the short term, switch to `--audit-level=critical` rather than restoring `continueOnError: true`.