### PR TITLE
docs: add READMEs and platform-api .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 .env.test.local
 .env.production.local
 
+# Local Copilot CLI session state (per-user, never committed)
+.copilot/
+
 # Testing
 coverage
 

--- a/apps/contoso-web-app/README.md
+++ b/apps/contoso-web-app/README.md
@@ -1,0 +1,52 @@
+# Contoso Web App
+
+> The flagship **Vibe Engineering** demo. Two routes show the same feature side-by-side: a "legacy vibe" (vibe-coded, vulnerable) implementation and a "secure vibe" (vibe-engineered, hardened) one.
+
+This app is intentionally small — its job is to make the security, validation, and design-system contrast visible at a glance, not to be a real product.
+
+## What's inside
+
+| Route | What it shows |
+| ----- | ------------- |
+| [`/legacy-vibe`](app/legacy-vibe/page.tsx) | Hardcoded markup, inline styles, raw SQL string concatenation, no input validation. Calls `/api/legacy-vibe`. |
+| [`/secure-vibe`](app/secure-vibe/page.tsx) | `@workspace/ui` components, Zod-validated inputs, safe DTOs. Calls `/api/secure-vibe`. |
+| [`/api/legacy-vibe`](app/api/legacy-vibe/route.ts) | Demonstrates SQL injection, returns sensitive fields. |
+| [`/api/secure-vibe`](app/api/secure-vibe/route.ts) | Parameterized queries via Drizzle, Zod-validated body, returns only safe fields. |
+
+The `/api/secure-vibe` route also has its markdown rendering sanitized (see PR #288).
+
+## Tech stack
+
+- **Next.js 15** (App Router, Server Components)
+- **React 19**, **Tailwind CSS 4**
+- **TypeScript** in strict mode
+- **`@workspace/ui`** for shared design tokens & components
+
+## Run it locally
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter contoso-web-app dev
+```
+
+The app starts on **http://localhost:3000**. No environment variables are required — the demo data is hardcoded.
+
+## Tests
+
+```bash
+pnpm --filter contoso-web-app test
+pnpm --filter contoso-web-app test:e2e   # Playwright
+```
+
+## Build
+
+```bash
+pnpm --filter contoso-web-app build
+```
+
+## See also
+
+- [`packages/ui`](../../packages/ui/README.md) — shared design system
+- [Root README](../../README.md) — monorepo overview & repo philosophy

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,3 +1,59 @@
 # `@workspace/eslint-config`
 
-Shared eslint configuration for the workspace.
+> Shared ESLint 9 (flat config) presets for the Vibe Engineering monorepo. Three drop-in configs: one for plain Node services, one for Next.js apps, and one for shared React libraries.
+
+## What's exported
+
+| File | When to use | Plugins enabled |
+| ---- | ----------- | --------------- |
+| [`base.js`](base.js) | Plain Node / TypeScript libraries (`services/*`, `packages/eslint-config`, etc.) | `@typescript-eslint`, `eslint-plugin-turbo`, `eslint-plugin-only-warn` |
+| [`next.js`](next.js) | Next.js apps (`apps/contoso-web-app`, `apps/octocat-*`) | base + `eslint-plugin-react`, `eslint-plugin-react-hooks`, `@next/eslint-plugin-next` |
+| [`react-internal.js`](react-internal.js) | Shared React libraries (`packages/ui`) | base + react + react-hooks (no Next.js plugin) |
+
+## Usage
+
+Pull the config you need into a per-package `eslint.config.js`:
+
+```js
+// apps/contoso-web-app/eslint.config.js
+import { nextJsConfig } from "@workspace/eslint-config/next-js";
+
+export default nextJsConfig;
+```
+
+```js
+// services/platform-api/eslint.config.js
+import { config } from "@workspace/eslint-config/base";
+
+export default config;
+```
+
+```js
+// packages/ui/eslint.config.js
+import { config } from "@workspace/eslint-config/react-internal";
+
+export default config;
+```
+
+## Extending
+
+The exported arrays follow ESLint's flat-config convention, so you can spread + extend in the consumer:
+
+```js
+import { config as baseConfig } from "@workspace/eslint-config/base";
+
+export default [
+  ...baseConfig,
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+];
+```
+
+## See also
+
+- [`packages/typescript-config`](../typescript-config/README.md) — companion shared `tsconfig` presets
+- [Root README](../../README.md) — monorepo overview
+

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,3 +1,63 @@
 # `@workspace/typescript-config`
 
-Shared typescript configuration for the workspace.
+> Shared `tsconfig` presets for the Vibe Engineering monorepo. Three drop-in configs covering Node services, Next.js apps, and shared React libraries — all opinionated for strict mode + modern module resolution.
+
+## What's exported
+
+| File | `display` name | When to use |
+| ---- | -------------- | ----------- |
+| [`base.json`](base.json) | `Default` | Plain Node / TypeScript services (`services/platform-api`, `services/medical-api`, etc.) |
+| [`nextjs.json`](nextjs.json) | `Next.js` | Next.js apps (`apps/contoso-web-app`, `apps/octocat-*`). Extends `base.json` and adds the Next.js plugin, `module: ESNext`, `moduleResolution: Bundler`, `noEmit`, JSX preserve, `allowJs`. |
+| [`react-library.json`](react-library.json) | `React Library` | Shared React component libraries (`packages/ui`). Extends `base.json` with JSX + React-friendly defaults. |
+
+## Common compiler options (set in `base.json`)
+
+- `strict: true` (all strict checks on)
+- `noUncheckedIndexedAccess: true` (array/record access returns `T | undefined`)
+- `isolatedModules: true` (every file must be independently transpilable)
+- `module: NodeNext` / `moduleResolution: NodeNext`
+- `target: ES2022`, `lib: [es2022, DOM, DOM.Iterable]`
+- `declaration: true`, `declarationMap: true`
+- `esModuleInterop: true`, `resolveJsonModule: true`
+- `skipLibCheck: true`
+
+## Usage
+
+Reference the config you need from your per-package `tsconfig.json`:
+
+```json
+// services/platform-api/tsconfig.json
+{
+  "extends": "@workspace/typescript-config/base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+```json
+// apps/contoso-web-app/tsconfig.json
+{
+  "extends": "@workspace/typescript-config/nextjs.json",
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+```json
+// packages/ui/tsconfig.json
+{
+  "extends": "@workspace/typescript-config/react-library.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+## Extending
+
+Override compiler options in the consuming `tsconfig.json` as needed — the shared base is intentionally strict so each package can relax options locally rather than fight a permissive default.
+
+## See also
+
+- [`packages/eslint-config`](../eslint-config/README.md) — companion shared ESLint presets
+- [Root README](../../README.md) — monorepo overview
+

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,82 @@
+# `@workspace/ui`
+
+> Shared design system for the Vibe Engineering monorepo. Thin shadcn/ui-style React 19 components built on Radix primitives, styled with Tailwind CSS 4.
+
+Used by all three apps (`contoso-web-app`, `octocat-blog-app`, `octocat-support-app`) via `"@workspace/ui": "workspace:*"`.
+
+## Components
+
+All components live in [`src/components/`](src/components/) and are exported individually:
+
+| Component | Source |
+| --------- | ------ |
+| `Alert`, `AlertTitle`, `AlertDescription` | [`alert.tsx`](src/components/alert.tsx) |
+| `Badge` | [`badge.tsx`](src/components/badge.tsx) |
+| `Button` (variants: `default`, `destructive`, `outline`, `secondary`, `ghost`, `link`) | [`button.tsx`](src/components/button.tsx) |
+| `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter` | [`card.tsx`](src/components/card.tsx) |
+| `Input` | [`input.tsx`](src/components/input.tsx) |
+| `Label` | [`label.tsx`](src/components/label.tsx) |
+| `Select`, `SelectTrigger`, `SelectContent`, `SelectItem`, `SelectValue` | [`select.tsx`](src/components/select.tsx) |
+| `Separator` | [`separator.tsx`](src/components/separator.tsx) |
+| `Textarea` | [`textarea.tsx`](src/components/textarea.tsx) |
+
+## Usage
+
+```tsx
+import { Button, Card, CardHeader, CardTitle, CardContent } from "@workspace/ui";
+
+export function Example() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Hello</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button variant="default">Click me</Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+Each component accepts `className` (merged via `tailwind-merge`) and forwards refs.
+
+## Design tokens & global styles
+
+Consumers import the Tailwind layer once in their app:
+
+```tsx
+// app/layout.tsx
+import "@workspace/ui/globals.css";
+```
+
+This exposes the design tokens (CSS custom properties for colors, radius, spacing) used by every component variant.
+
+## Tailwind config
+
+Apps share the PostCSS config:
+
+```js
+// postcss.config.mjs
+export { default } from "@workspace/ui/postcss.config";
+```
+
+## Tests
+
+```bash
+pnpm --filter @workspace/ui test
+```
+
+Tests use Jest + React Testing Library + jsdom. See [`src/components/__tests__/`](src/components/__tests__/).
+
+> The Radix `Select` dropdown test only covers the trigger because jsdom lacks `PointerEvent` support — see issue [#294](https://github.com/VeVarunSharma/contoso-vibe-engineering/issues/294) for the polyfill that would unlock those tests.
+
+## Lint
+
+```bash
+pnpm --filter @workspace/ui lint
+```
+
+## Hooks
+
+`src/hooks/` is currently empty (only `.gitkeep`). The `./hooks/*` export pattern is reserved for future shared hooks.

--- a/services/platform-api/.env.example
+++ b/services/platform-api/.env.example
@@ -1,0 +1,10 @@
+# PostgreSQL connection string used by Drizzle ORM (required)
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/platform_api
+
+# Port the Express server listens on (optional, default 3001)
+PORT=3001
+
+# Bearer token required for POST /users (and any other mutating routes).
+# Generate a strong random value for non-local environments, e.g.:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+PLATFORM_API_TOKEN=dev-token-do-not-use-in-prod

--- a/services/platform-api/README.md
+++ b/services/platform-api/README.md
@@ -1,0 +1,68 @@
+# Platform API
+
+> A small Express + Drizzle service that backs the demo apps. Demonstrates the "vibe-engineered" backend pattern: typed routes, parameterized queries, rate limiting, and bearer-token auth on mutations.
+
+## Tech stack
+
+| Layer | Library |
+| ----- | ------- |
+| Framework | [Express 4](https://expressjs.com/) |
+| ORM | [Drizzle](https://orm.drizzle.team/) (PostgreSQL) |
+| Validation | [Zod](https://zod.dev/) |
+| Auth | Bearer token (`PLATFORM_API_TOKEN` env) — see [`src/middleware/auth.ts`](src/middleware/auth.ts) |
+| Rate limiting | [`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit) — see PR #290 |
+| Tests | Jest + supertest |
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| `GET` | `/health` | none | Liveness probe |
+| `GET` | `/users` | none | List users (safe DTO — no password hashes) |
+| `POST` | `/users` | Bearer | Create a user |
+
+See [`src/routes/`](src/routes/) for full handler source.
+
+## Quick start
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+- PostgreSQL 15+
+
+### Environment
+
+Copy [`.env.example`](.env.example) to `.env` and fill in your database URL & auth token.
+
+### Database setup
+
+```bash
+cd services/platform-api
+pnpm db:generate    # generate Drizzle migrations from schema
+pnpm db:migrate     # apply migrations to the database
+pnpm db:seed        # seed with sample users (uses @faker-js/faker)
+```
+
+### Run
+
+```bash
+pnpm dev      # tsx watch
+pnpm build    # tsc
+pnpm start    # node dist/index.js
+```
+
+Service listens on **http://localhost:3001** by default (override with `PORT`).
+
+## Tests
+
+```bash
+pnpm test
+```
+
+Tests use a separate `DATABASE_URL` (set in `src/__tests__/setup.ts`). The repo CI runs them via `pnpm --filter platform-api test`.
+
+## See also
+
+- [`services/medical-api`](../medical-api/README.md) — JWT-auth'd healthcare API (PIPA BC)
+- [Root README](../../README.md) — monorepo overview


### PR DESCRIPTION
## Summary

Adds onboarding docs that were the largest gaps in the repo.

| File | Closes |
| ---- | ------ |
| `apps/contoso-web-app/README.md` | #236 |
| `services/platform-api/README.md` | #237 |
| `services/platform-api/.env.example` | #238 |
| `packages/ui/README.md` | #240 |
| `packages/eslint-config/README.md` (expanded) | #241 |
| `packages/typescript-config/README.md` (expanded) | #242 |

Also adds `.copilot/` to `.gitignore` — it's per-user Copilot CLI session state and should never be committed.

## Why

Each README explains *what's in the package*, *how to use it*, *how to run it*, and *where to look next* — calibrated to the demo's purpose. The platform-api `.env.example` documents the three env vars (`DATABASE_URL`, `PORT`, `PLATFORM_API_TOKEN`) that were only discoverable by grepping the source.

#239 (`.env.example` for contoso-web-app) will be closed separately as not-needed — that app uses no environment variables.

## Test plan

- Markdown-only; renders correctly.
- No code changed → no tests required.