### PR TITLE
feat(apps): add error/loading/not-found boundaries to all three apps

### DIFF
--- a/apps/contoso-web-app/app/error.tsx
+++ b/apps/contoso-web-app/app/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+      <div className="max-w-md">
+        <p className="text-sm font-semibold text-red-600 uppercase tracking-wider mb-2">
+          Error
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight mb-3">
+          Something went wrong
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          An unexpected error occurred. You can try again, or return to the
+          homepage.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-muted-foreground mb-6 font-mono">
+            Error reference: {error.digest}
+          </p>
+        )}
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-black/90 transition-colors"
+          >
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent transition-colors"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/contoso-web-app/app/loading.tsx
+++ b/apps/contoso-web-app/app/loading.tsx
@@ -1,0 +1,11 @@
+export default function Loading() {
+  return (
+    <main
+      className="flex min-h-screen items-center justify-center"
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-current border-t-transparent text-muted-foreground" />
+    </main>
+  );
+}

--- a/apps/contoso-web-app/app/not-found.tsx
+++ b/apps/contoso-web-app/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+      <div className="max-w-md">
+        <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+          404
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight mb-3">
+          Page not found
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          The page you&apos;re looking for doesn&apos;t exist. It may have been
+          moved or removed.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex items-center rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-black/90 transition-colors"
+        >
+          Back to home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/octocat-blog-app/app/error.tsx
+++ b/apps/octocat-blog-app/app/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="container flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <AlertTriangle className="h-20 w-20 text-destructive mb-6" aria-hidden="true" />
+      <h1 className="text-3xl font-bold mb-3">Something went wrong</h1>
+      <p className="text-muted-foreground max-w-md mb-8">
+        An unexpected error occurred while loading this page. Try again, or head
+        back to the homepage.
+      </p>
+      {error.digest && (
+        <p className="text-xs text-muted-foreground mb-6 font-mono">
+          Error reference: {error.digest}
+        </p>
+      )}
+      <div className="flex gap-3">
+        <Button onClick={reset} variant="default">
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/octocat-support-app/app/error.tsx
+++ b/apps/octocat-support-app/app/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertCircle, RefreshCw, Home } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="container flex flex-col items-center justify-center min-h-[70vh] px-4 text-center">
+      <AlertCircle
+        className="h-16 w-16 text-destructive mb-6"
+        aria-hidden="true"
+      />
+      <h1 className="text-3xl font-bold tracking-tight mb-3">
+        Something went wrong
+      </h1>
+      <p className="text-muted-foreground max-w-md mb-6">
+        We hit an unexpected error while loading this page. Try again, or head
+        back to the support home.
+      </p>
+      {error.digest && (
+        <p className="text-xs text-muted-foreground mb-6 font-mono">
+          Error reference: {error.digest}
+        </p>
+      )}
+      <div className="flex gap-3">
+        <Button onClick={reset}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/octocat-support-app/app/loading.tsx
+++ b/apps/octocat-support-app/app/loading.tsx
@@ -1,0 +1,16 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <main
+      className="flex items-center justify-center min-h-[60vh]"
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <Loader2
+        className="h-8 w-8 animate-spin text-muted-foreground"
+        aria-hidden="true"
+      />
+    </main>
+  );
+}

--- a/apps/octocat-support-app/app/not-found.tsx
+++ b/apps/octocat-support-app/app/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { FileQuestion, Home } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+
+export default function NotFound() {
+  return (
+    <main className="container flex flex-col items-center justify-center min-h-[70vh] px-4 text-center">
+      <FileQuestion
+        className="h-16 w-16 text-muted-foreground mb-6"
+        aria-hidden="true"
+      />
+      <h1 className="text-3xl font-bold tracking-tight mb-3">
+        Page not found
+      </h1>
+      <p className="text-muted-foreground max-w-md mb-6">
+        We couldn&apos;t find the page you&apos;re looking for. It may have been
+        moved, or the link might be incorrect.
+      </p>
+      <Button asChild>
+        <Link href="/">
+          <Home className="mr-2 h-4 w-4" />
+          Back to support
+        </Link>
+      </Button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the missing Next.js App Router boundaries so unhandled errors don't fall back to the default 500 page and loading states are explicit.

| App | Added |
| --- | ----- |
| contoso-web-app | error.tsx + loading.tsx + not-found.tsx (all three were missing) |
| octocat-blog-app | error.tsx (loading.tsx and not-found.tsx already existed) |
| octocat-support-app | error.tsx + loading.tsx + not-found.tsx (all three were missing) |

## Conventions used

- **error.tsx** is a Client Component (`'use client'`) — Next.js requirement.
- Errors are logged to `console.error` for telemetry, and `error.digest` is surfaced for support correlation.
- Each error page offers **Try again** (calls `reset()`) and **Go home** recovery actions.
- Loading boundaries set `aria-busy="true"` for screen-reader accessibility.
- Visual style matches each app's existing language (shared-UI for blog/support; inline Tailwind for contoso-web-app which uses minimal styling).

## Closes

- Closes #243
- Closes #244
- Closes #245

## Test plan

- New boundary files only — no existing routes touched.
- Boundaries activate automatically on error; manual smoke after merge: `pnpm dev` → throw inside any page → see styled error UI.