### PR TITLE
fix: real bugs flagged in repo cleanup triage (4 issues)

### DIFF
--- a/apps/octocat-blog-app/app/page.tsx
+++ b/apps/octocat-blog-app/app/page.tsx
@@ -105,29 +105,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* Newsletter Section */}
-      <section className="border-t bg-muted/30 py-16">
-        <div className="container mx-auto px-4 md:px-8 text-center">
-          <h2 className="text-3xl font-bold mb-4">Stay in the Loop</h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto mb-8">
-            Get the latest GitHub updates, feature announcements, and
-            engineering insights delivered straight to your inbox.
-          </p>
-          <form className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-            <input
-              type="email"
-              placeholder="Enter your email"
-              className="flex-1 rounded-md border bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-            <button
-              type="submit"
-              className="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Subscribe
-            </button>
-          </form>
-        </div>
-      </section>
+      {/* End of posts */}
     </>
   );
 }

--- a/apps/octocat-blog-app/app/post/[slug]/page.tsx
+++ b/apps/octocat-blog-app/app/post/[slug]/page.tsx
@@ -76,6 +76,10 @@ export default async function PostPage({ params }: PostPageProps) {
   const wordCount = post.content.split(/\s+/).length;
   const readingTime = Math.ceil(wordCount / 200);
 
+  const siteUrl =
+    process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") ??
+    "http://localhost:3001";
+
   return (
     <article className="container max-w-4xl px-4 md:px-8 py-12">
       {/* Back link */}
@@ -179,7 +183,7 @@ export default async function PostPage({ params }: PostPageProps) {
       <div className="flex items-center gap-4 pt-8 border-t">
         <span className="text-sm font-medium">Share this post:</span>
         <a
-          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`https://octocat-blog.example.com/post/${post.slug}`)}`}
+          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`${siteUrl}/post/${post.slug}`)}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground hover:text-primary"
@@ -187,7 +191,7 @@ export default async function PostPage({ params }: PostPageProps) {
           Twitter
         </a>
         <a
-          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(`https://octocat-blog.example.com/post/${post.slug}`)}`}
+          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(`${siteUrl}/post/${post.slug}`)}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground hover:text-primary"

--- a/services/ai-tool-digest/src/logging.ts
+++ b/services/ai-tool-digest/src/logging.ts
@@ -1,5 +1,4 @@
 import applicationInsights from "applicationinsights";
-// TODO FIX THIS as InvocationContext type is not being resolved correctly
 import type { InvocationContext } from "@azure/functions";
 
 let telemetryClient: applicationInsights.TelemetryClient | undefined;
@@ -15,11 +14,33 @@ export function initialiseTelemetry(connectionString?: string): void {
   telemetryClient = applicationInsights.defaultClient;
 }
 
+function stringifyProperties(
+  properties?: Record<string, unknown>
+): { [key: string]: string } | undefined {
+  if (!properties) return undefined;
+  const result: { [key: string]: string } = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined || value === null) {
+      result[key] = String(value);
+    } else if (typeof value === "string") {
+      result[key] = value;
+    } else if (typeof value === "object") {
+      result[key] = JSON.stringify(value);
+    } else {
+      result[key] = String(value);
+    }
+  }
+  return result;
+}
+
 export function trackEvent(
   name: string,
   properties?: Record<string, unknown>
 ): void {
-  telemetryClient?.trackEvent({ name, properties: properties as any });
+  telemetryClient?.trackEvent({
+    name,
+    properties: stringifyProperties(properties),
+  });
 }
 
 export function trackException(error: Error): void {
@@ -34,3 +55,4 @@ export function logContext(
   const payload = data ? `${message} ${JSON.stringify(data)}` : message;
   context.log(payload);
 }
+


### PR DESCRIPTION
## Summary

Three small but real bugs surfaced during the cleanup triage:

| # | Bug | Fix |
| --- | --- | --- |
| #262 | Hardcoded `octocat-blog.example.com` in blog post Twitter/LinkedIn share URLs (issue text said support-app, but the bug is actually in `apps/octocat-blog-app/app/post/[slug]/page.tsx`) | Derive `siteUrl` from `process.env.NEXT_PUBLIC_APP_URL` (already documented in the app's `.env.example`) with a localhost fallback |
| #263 | Dead newsletter `<form>` with no submit handler on blog homepage | Removed the entire section — re-add later if there's a real backend + consent UX |
| #257, #260 | `properties as any` + stale `InvocationContext` TODO in ai-tool-digest `logging.ts` | applicationinsights `trackEvent` wants `{[key: string]: string}`; now serializes properties properly (objects → JSON, scalars → String). Removed the stale TODO — the import resolves fine. |

## Closes

- Closes #257
- Closes #260
- Closes #262
- Closes #263

## Test plan

- `pnpm --filter octocat-blog-app typecheck` — clean.
- Standalone typecheck of `services/ai-tool-digest/src/logging.ts` — clean. (Note: `pnpm --filter ai-tool-digest build` has pre-existing TS5110 / `@jest/globals` errors unrelated to this change, on `main` today.)
- Blog homepage — newsletter section gone, no other layout regressions visible.
- Blog post page — share URLs now hit the live host (or localhost in dev).