### PR TITLE
chore: a11y polish + GitHub templates (+ typecheck fix)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature, improvement, or capability for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+**Problem / motivation**
+What's the user-facing problem you're trying to solve? What's the demo or workflow that this would enable?
+
+**Proposed solution**
+A clear description of what you want to happen. Sketch the API, UI, or workflow if helpful.
+
+**Alternatives considered**
+Other approaches you weighed and why this one wins (or why others were ruled out).
+
+**Scope**
+- [ ] Frontend (`apps/*`)
+- [ ] Shared package (`packages/*`)
+- [ ] Backend service (`services/*`)
+- [ ] Infrastructure (`infra/*`)
+- [ ] Tooling / CI (`.github/*`, scripts)
+- [ ] Documentation only
+
+**Acceptance criteria**
+Concrete, verifiable signals that the feature is done:
+- [ ] …
+- [ ] …
+- [ ] …
+
+**Additional context**
+Screenshots, mockups, related issues, prior art, or links to relevant docs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+Thanks for the PR! Filling this in helps reviewers (and your future self) move faster.
+Delete sections that don't apply.
+-->
+
+## Summary
+
+What changes and why. One paragraph.
+
+## Linked issues
+
+<!-- Use "Closes #N" so the issue auto-closes on merge. -->
+
+- Closes #
+- Related to #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior in a non-backwards-compatible way)
+- [ ] Docs / chore (no production code change)
+
+## Affected areas
+
+- [ ] `apps/contoso-web-app`
+- [ ] `apps/octocat-blog-app`
+- [ ] `apps/octocat-support-app`
+- [ ] `packages/ui`
+- [ ] `packages/eslint-config` / `packages/typescript-config`
+- [ ] `services/platform-api`
+- [ ] `services/medical-api`
+- [ ] `services/ai-tool-digest`
+- [ ] `services/rigidport`
+- [ ] `infra/*`
+- [ ] CI / GitHub Actions / Squad workflows
+
+## Test plan
+
+How did you verify this works? Reviewers should be able to reproduce.
+
+- [ ] `pnpm install` succeeds
+- [ ] `pnpm lint` (or `pnpm --filter <pkg> lint`) passes
+- [ ] `pnpm test` (or `pnpm --filter <pkg> test`) passes
+- [ ] Manual smoke: …
+
+## Screenshots / output
+
+<!-- Optional but appreciated for UI changes. -->
+
+## Checklist
+
+- [ ] My changes follow the conventions in `AGENTS.md` / `.github/instructions/`
+- [ ] I added or updated tests where it made sense
+- [ ] I updated relevant READMEs / docs
+- [ ] No secrets, tokens, or PII committed

--- a/apps/contoso-web-app/components/site-header.tsx
+++ b/apps/contoso-web-app/components/site-header.tsx
@@ -7,13 +7,20 @@ export function SiteHeader() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
         <div className="mr-4 flex">
-          <Link href="/" className="mr-6 flex items-center space-x-2">
-            <Code2 className="h-6 w-6" />
+          <Link
+            href="/"
+            className="mr-6 flex items-center space-x-2"
+            aria-label="Contoso Vibe home"
+          >
+            <Code2 className="h-6 w-6" aria-hidden="true" />
             <span className="hidden font-bold sm:inline-block">
               Contoso Vibe
             </span>
           </Link>
-          <nav className="flex items-center space-x-6 text-sm font-medium">
+          <nav
+            className="flex items-center space-x-6 text-sm font-medium"
+            aria-label="Main"
+          >
             <Link
               href="#mission"
               className="transition-colors hover:text-foreground/80 text-foreground/60"
@@ -35,12 +42,13 @@ export function SiteHeader() {
           </nav>
         </div>
         <div className="flex flex-1 items-center justify-end space-x-2">
-          <nav className="flex items-center">
+          <nav className="flex items-center" aria-label="Account">
             <Button variant="ghost" size="sm" asChild>
               <Link
                 href="https://github.com/contoso-vibe"
                 target="_blank"
                 rel="noreferrer"
+                aria-label="Open GitHub organization in a new tab"
               >
                 GitHub
               </Link>

--- a/apps/contoso-web-app/config/jest/jest.d.ts
+++ b/apps/contoso-web-app/config/jest/jest.d.ts
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeInTheDocument(): R;
+      toBeVisible(): R;
+      toBeEmptyDOMElement(): R;
+      toBeDisabled(): R;
+      toBeEnabled(): R;
+      toBeInvalid(): R;
+      toBeRequired(): R;
+      toBeValid(): R;
+      toContainElement(element: HTMLElement | null): R;
+      toContainHTML(htmlText: string): R;
+      toHaveAccessibleDescription(expectedDescription?: string | RegExp): R;
+      toHaveAccessibleName(expectedName?: string | RegExp): R;
+      toHaveAttribute(attr: string, value?: unknown): R;
+      toHaveClass(...classNames: string[]): R;
+      toHaveFocus(): R;
+      toHaveFormValues(expectedValues: Record<string, unknown>): R;
+      toHaveStyle(css: string | Record<string, unknown>): R;
+      toHaveTextContent(
+        text: string | RegExp,
+        options?: { normalizeWhitespace: boolean }
+      ): R;
+      toHaveValue(value: string | string[] | number | null): R;
+      toHaveDisplayValue(value: string | RegExp | Array<string | RegExp>): R;
+      toBeChecked(): R;
+      toBePartiallyChecked(): R;
+      toHaveErrorMessage(text?: string | RegExp): R;
+    }
+  }
+}

--- a/apps/octocat-blog-app/components/category-badge.tsx
+++ b/apps/octocat-blog-app/components/category-badge.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Tag } from "lucide-react";
 import type { Category } from "@/src/db/schema";
 
 interface CategoryBadgeProps {
@@ -12,13 +13,18 @@ export function CategoryBadge({ category, size = "sm" }: CategoryBadgeProps) {
     md: "px-3 py-1 text-sm",
   };
 
+  const iconSize = size === "sm" ? "h-3 w-3" : "h-4 w-4";
+
   return (
     <Link
       href={`/category/${category.slug}`}
-      className={`inline-flex items-center rounded-full font-medium text-white transition-opacity hover:opacity-90 ${sizeClasses[size]}`}
+      className={`inline-flex items-center gap-1 rounded-full font-medium text-white transition-opacity hover:opacity-90 ${sizeClasses[size]}`}
       style={{ backgroundColor: category.color || "#24292f" }}
+      aria-label={`View all posts in category: ${category.name}`}
     >
+      <Tag className={iconSize} aria-hidden="true" />
       {category.name}
     </Link>
   );
 }
+

--- a/apps/octocat-blog-app/components/post-card.tsx
+++ b/apps/octocat-blog-app/components/post-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { formatDistanceToNow } from "date-fns";
+import { Tag } from "lucide-react";
 import type { Post, Author, Category } from "@/src/db/schema";
 
 interface PostCardProps {
@@ -34,9 +35,11 @@ export function PostCard({ post, featured = false }: PostCardProps) {
           )}
           <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
             <span
-              className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium mb-3"
+              className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium mb-3"
               style={{ backgroundColor: post.category.color || "#24292f" }}
+              aria-label={`Category: ${post.category.name}`}
             >
+              <Tag className="h-3 w-3" aria-hidden="true" />
               {post.category.name}
             </span>
             <h2 className="text-2xl md:text-3xl font-bold mb-2 line-clamp-2">
@@ -82,9 +85,11 @@ export function PostCard({ post, featured = false }: PostCardProps) {
         )}
         <div className="flex flex-1 flex-col p-4">
           <span
-            className="inline-flex w-fit items-center rounded-full px-2.5 py-0.5 text-xs font-medium text-white mb-2"
+            className="inline-flex w-fit items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium text-white mb-2"
             style={{ backgroundColor: post.category.color || "#24292f" }}
+            aria-label={`Category: ${post.category.name}`}
           >
+            <Tag className="h-3 w-3" aria-hidden="true" />
             {post.category.name}
           </span>
           <h3 className="text-lg font-semibold mb-2 line-clamp-2 group-hover:text-primary transition-colors">


### PR DESCRIPTION
## Summary

Closes 4 issues with minor follow-up wins.

### A11y (#255, #256)

- `contoso-web-app/components/site-header.tsx` — both `<nav>` elements now get `aria-label` ("Main" and "Account"), the home Link gets a label, decorative icons get `aria-hidden="true"`, and the external GitHub Link tells screen readers it opens in a new tab.
- `octocat-blog-app/components/post-card.tsx` + `category-badge.tsx` — category badges now include a `Tag` icon **and** `aria-label="Category: X"`. A user with color-blindness or in monochrome can still identify the badge as a category by its icon + text, not just background color.

### Templates (#266, #267)

- `.github/pull_request_template.md` — structured PR template with linked-issues, affected-areas checklist, and test plan.
- `.github/ISSUE_TEMPLATE/feature_request.md` — dedicated feature request template alongside existing bug_report / general_issue / refactor_request.

### Drive-by fix

`pnpm --filter contoso-web-app typecheck` was broken on `main` today — jest-dom matchers (`toBeInTheDocument`, `toHaveAttribute`, etc.) had no TypeScript definitions visible. Added `apps/contoso-web-app/config/jest/jest.d.ts` mirroring the same file in `octocat-blog-app`. `tsc --noEmit` now clean.

## Closes

- Closes #255
- Closes #256
- Closes #266
- Closes #267

## Test plan

- `pnpm --filter contoso-web-app typecheck` — clean.
- `pnpm --filter octocat-blog-app typecheck` — clean.
- Templates render via GitHub UI on new issues/PRs (will be exercised by the next contributor).