### PR TITLE
chore: quick wins — DB-aware health check, service ESLint configs, jsdom PointerEvent polyfill

### DIFF
--- a/packages/ui/jest.setup.cjs
+++ b/packages/ui/jest.setup.cjs
@@ -1,1 +1,20 @@
 require("@testing-library/jest-dom");
+
+// Polyfill PointerEvent APIs that jsdom lacks but Radix UI requires.
+// Without these, tests that open a Radix Select / Dialog / Dropdown throw
+// `TypeError: target.hasPointerCapture is not a function`. See issue #294.
+if (typeof window !== "undefined") {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,9 +529,15 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@workspace/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.8
+      eslint:
+        specifier: ^9.32.0
+        version: 9.32.0(jiti@2.5.1)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@20.19.37)(typescript@5.9.2))
@@ -2072,7 +2078,6 @@ packages:
   '@next/swc-win32-x64-msvc@16.1.6':
     resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
     engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@noble/hashes@1.8.0':

--- a/services/medical-api/eslint.config.js
+++ b/services/medical-api/eslint.config.js
@@ -1,0 +1,9 @@
+import { config } from "@workspace/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default [
+  ...config,
+  {
+    ignores: ["dist/**", "drizzle/**", "coverage/**"],
+  },
+];

--- a/services/medical-api/package.json
+++ b/services/medical-api/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "lint": "eslint .",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/db/seed.ts",
@@ -29,10 +30,13 @@
     "@types/node": "^20.19.9",
     "@types/pg": "^8.11.0",
     "@types/uuid": "^10.0.0",
+    "@workspace/eslint-config": "workspace:*",
     "drizzle-kit": "^0.31.8",
+    "eslint": "^9.32.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.6",
     "tsx": "^4.15.0",
     "typescript": "^5.9.2"
   }
 }
+

--- a/services/platform-api/eslint.config.js
+++ b/services/platform-api/eslint.config.js
@@ -1,0 +1,9 @@
+import { config } from "@workspace/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default [
+  ...config,
+  {
+    ignores: ["dist/**", "drizzle/**", "coverage/**"],
+  },
+];

--- a/services/platform-api/src/routes/__tests__/health.test.ts
+++ b/services/platform-api/src/routes/__tests__/health.test.ts
@@ -1,26 +1,64 @@
 import request from "supertest";
-import { createServer } from "../../server.js";
+import express from "express";
+import { jest } from "@jest/globals";
+import { createHealthRouter } from "../health.js";
+
+/**
+ * Mount the health router with a stubbed dbPing so tests don't need a real
+ * Postgres connection.
+ */
+function buildAppWithPing(dbPing: () => Promise<void>) {
+  const app = express();
+  app.use("/health", createHealthRouter(dbPing));
+  return app;
+}
 
 describe("GET /health", () => {
-  const app = createServer();
+  it("returns 200 with status: ok and db: up when the DB ping resolves", async () => {
+    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const app = buildAppWithPing(dbPing);
 
-  it("returns 200 with status: ok", async () => {
     const res = await request(app).get("/health");
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body).toEqual({ status: "ok", db: "up" });
+    expect(dbPing).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 with status: degraded when the DB ping rejects", async () => {
+    const dbPing = jest
+      .fn()
+      .mockRejectedValue(new Error("connection refused"));
+    const app = buildAppWithPing(dbPing);
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      status: "degraded",
+      db: "down",
+      error: "connection refused",
+    });
   });
 
   it("responds to a trailing slash too", async () => {
+    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const app = buildAppWithPing(dbPing);
+
     const res = await request(app).get("/health/");
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body).toEqual({ status: "ok", db: "up" });
   });
 
   it("returns JSON content-type", async () => {
+    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const app = buildAppWithPing(dbPing);
+
     const res = await request(app).get("/health");
 
     expect(res.headers["content-type"]).toMatch(/application\/json/);
   });
 });
+
+

--- a/services/platform-api/src/routes/health.ts
+++ b/services/platform-api/src/routes/health.ts
@@ -1,9 +1,38 @@
 import { Router, type Router as RouterType } from "express";
+import { sql } from "drizzle-orm";
+import { db } from "../db/index.js";
 
-const router: Router = Router();
+/**
+ * Default implementation: runs a trivial `SELECT 1` against the configured
+ * Postgres pool. Exposed as a parameter to `createHealthRouter` so tests
+ * can inject a fake without needing a live DB connection.
+ */
+export const defaultDbPing = async (): Promise<void> => {
+  await db.execute(sql`SELECT 1`);
+};
 
-router.get("/", (req, res) => {
-  res.json({ status: "ok" });
-});
+export const createHealthRouter = (
+  dbPing: () => Promise<void> = defaultDbPing
+): RouterType => {
+  const router = Router();
+
+  router.get("/", async (_req, res) => {
+    try {
+      await dbPing();
+      return res.status(200).json({ status: "ok", db: "up" });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Database health check failed";
+      console.error("Health check DB error:", message);
+      return res
+        .status(503)
+        .json({ status: "degraded", db: "down", error: message });
+    }
+  });
+
+  return router;
+};
+
+const router: Router = createHealthRouter();
 
 export default router;


### PR DESCRIPTION
## Summary

Three small fixes from the P2/P3 backlog.

### 1. Platform-api health check now validates DB (#252)

**Before:** `/health` always returned `200 { status: 'ok' }`, even with Postgres down.

**After:**
- `200 { status: 'ok', db: 'up' }` on a successful `SELECT 1`.
- `503 { status: 'degraded', db: 'down', error: '<msg>' }` if the query throws.

Refactored the route into a `createHealthRouter(dbPing)` factory so unit tests can inject a fake without needing a live Postgres connection. Tests updated to cover both paths (4 tests, all passing).

### 2. Explicit ESLint configs for medical-api and platform-api (#265)

Both services had a `lint: 'eslint .'` script (or no script at all, in medical-api's case) and relied on the root config falling through. Now each has its own `eslint.config.js` extending `@workspace/eslint-config/base`. medical-api also gained the missing `eslint` + `@workspace/eslint-config` devDependencies and a `lint` script.

Both now lint clean (warnings only — all are pre-existing `turbo/no-undeclared-env-vars` notices).

### 3. jsdom PointerEvent polyfill in packages/ui (#294)

Added `hasPointerCapture`, `releasePointerCapture`, `setPointerCapture`, and `scrollIntoView` shims to `packages/ui/jest.setup.cjs`. Future Radix `Select` / `Dialog` / `Dropdown` interaction tests can now open the popover without throwing `target.hasPointerCapture is not a function`. All 37 existing UI tests still pass.

## Closes

- Closes #252
- Closes #265
- Closes #294

## Test plan

- `pnpm --filter platform-api test` — 4/4 pass (success + degraded + trailing-slash + content-type)
- `pnpm --filter medical-api test` — 32/32 pass
- `pnpm --filter medical-api lint` — clean (0 errors, 6 warnings, all pre-existing)
- `pnpm --filter platform-api lint` — clean (0 errors, warnings only)
- `pnpm --filter @workspace/ui test` — 37/37 pass