### PR TITLE
feat(medical-api): add production Dockerfile (#250)

### DIFF
--- a/services/medical-api/.dockerignore
+++ b/services/medical-api/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+.env*
+*.log
+__tests__
+*.md
+.turbo

--- a/services/medical-api/Dockerfile
+++ b/services/medical-api/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+ENV PNPM_HOME=/pnpm
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY services/medical-api/package.json services/medical-api/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
+COPY packages/typescript-config/package.json packages/typescript-config/package.json
+
+RUN pnpm install --frozen-lockfile --filter @contoso/medical-api...
+
+COPY services/medical-api/tsconfig.json services/medical-api/tsconfig.json
+COPY services/medical-api/src services/medical-api/src
+
+RUN pnpm --filter @contoso/medical-api build \
+  && pnpm deploy --filter @contoso/medical-api --prod --legacy /prod/medical-api
+
+FROM node:20-alpine AS runtime
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=builder --chown=node:node /prod/medical-api ./
+
+USER node
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "const port = process.env.PORT || '3001'; fetch('http://127.0.0.1:' + port + '/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1));"
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Problem

`services/medical-api` did not have a production-ready container build definition for independent deployment.

## Approach

- Added a multi-stage Dockerfile for the Hono/Node 20 service.
- Builder stage uses `node:20-alpine`, activates `pnpm@10.26.2`, installs the filtered workspace with `@contoso/medical-api...`, builds TypeScript, and deploys production dependencies with `pnpm deploy --prod --legacy`.
- Runtime stage uses `node:20-alpine`, runs as the non-root `node` user, sets `NODE_ENV=production`, exposes the actual default service port `3001`, and healthchecks `/health`.
- Added a service-level `.dockerignore` for local build artifacts, env files, logs, tests, markdown, and Turborepo output.

## Image layout

Runtime image copies the deployed app from the builder output, including:

- `dist/`
- `package.json`
- production `node_modules/`

The container starts with `node dist/index.js`.

## Validation

- `npx --yes pnpm@10.26.2 install --frozen-lockfile --filter @contoso/medical-api...` succeeded.
- `npx --yes pnpm@10.26.2 --filter @contoso/medical-api build` succeeded and produced `dist/index.js`.
- `docker build --progress=plain -t medical-api:test -f services/medical-api/Dockerfile .` succeeded from the repository root.
- Runtime smoke checks confirmed the image runs as UID `1000`, includes `dist/index.js`, includes production deps, excludes `typescript`, and returns `200 {"status":"ok","service":"medical-api"}` from `/health` when `DATABASE_URL` is provided.

Closes #250

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
