### PR TITLE
feat(platform-api): add production Dockerfile (#251)

### DIFF
--- a/services/platform-api/.dockerignore
+++ b/services/platform-api/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+.env*
+*.log
+__tests__
+*.md
+.turbo

--- a/services/platform-api/Dockerfile
+++ b/services/platform-api/Dockerfile
@@ -1,0 +1,38 @@
+# Build from the repository root: docker build -t platform-api:test -f services/platform-api/Dockerfile .
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY services/platform-api/package.json ./services/platform-api/package.json
+COPY packages/eslint-config/package.json ./packages/eslint-config/package.json
+COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
+
+RUN pnpm install --frozen-lockfile --filter platform-api...
+
+COPY packages/typescript-config ./packages/typescript-config
+COPY services/platform-api/tsconfig.json ./services/platform-api/tsconfig.json
+COPY services/platform-api/src ./services/platform-api/src
+
+RUN pnpm --filter platform-api build
+RUN pnpm --filter platform-api --prod deploy /prod/platform-api --legacy
+
+FROM node:20-alpine AS runtime
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=builder --chown=node:node /prod/platform-api/node_modules ./node_modules
+COPY --from=builder --chown=node:node /prod/platform-api/package.json ./package.json
+COPY --from=builder --chown=node:node /app/services/platform-api/dist ./dist
+
+USER node
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "const port = process.env.PORT || 3001; fetch('http://127.0.0.1:' + port + '/health').then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "dist/index.js"]

--- a/services/platform-api/tsconfig.json
+++ b/services/platform-api/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

`services/platform-api` did not have a production container definition, making independent deployment of the Express service harder to standardize.

## Approach

- Added a multi-stage `node:20-alpine` Dockerfile for `platform-api`.
- Enabled Corepack and pinned pnpm to `10.26.2` in the builder.
- Installed workspace dependencies with `pnpm install --frozen-lockfile --filter platform-api...`.
- Built the service with `pnpm --filter platform-api build`.
- Used `pnpm --filter platform-api --prod deploy /prod/platform-api --legacy` to prepare production-only dependencies.
- Added a service-level `.dockerignore` for common generated, secret, and test artifacts.
- Updated the production TypeScript build config to exclude test files so `dist/index.js` is emitted without test-only imports.

## Image layout

- Runtime image: `node:20-alpine`
- Runtime user: `node`
- Workdir: `/app`
- Shipped artifacts: production `node_modules`, `package.json`, and `dist/`
- Port: `3001` from `services/platform-api/src/index.ts`
- Healthcheck: `GET /health`
- Start command: `node dist/index.js`

## Validation

- `npx -y pnpm@10.26.2 --filter platform-api build` ✅
- `npx -y pnpm@10.26.2 --filter platform-api test` ✅
- `docker build -t platform-api:test -f services/platform-api/Dockerfile .` ✅
- `docker run --rm --entrypoint sh platform-api:test -c 'test -f dist/index.js && test ! -d node_modules/typescript && [ "$(id -un)" = node ] && echo "runtime layout ok"'` ✅

Closes #251

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
