### PR TITLE
feat(platform-api): Zod input validation + /users pagination (#253)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       '@faker-js/faker':
         specifier: ^10.1.0
         version: 10.1.0
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19

--- a/services/platform-api/package.json
+++ b/services/platform-api/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",
+    "@jest/globals": "29.7.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",

--- a/services/platform-api/src/middleware/__tests__/validate.test.ts
+++ b/services/platform-api/src/middleware/__tests__/validate.test.ts
@@ -1,0 +1,158 @@
+import express from "express";
+import request from "supertest";
+import { z } from "zod";
+import { users } from "../../db/schema.js";
+import { createUsersRouter } from "../../routes/users.js";
+import { validate, type ValidatedRequest } from "../validate.js";
+
+const authToken = "test-platform-token-123456789012345";
+
+type UserRecord = typeof users.$inferSelect;
+type FindManyOptions = { limit: number; offset: number };
+
+beforeAll(() => {
+  process.env.PLATFORM_API_TOKEN = authToken;
+});
+
+describe("validate middleware", () => {
+  it("rejects an invalid body with 400 and structured Zod issues", async () => {
+    const bodySchema = z.object({ name: z.string().min(1) });
+    const app = express();
+
+    app.use(express.json());
+    app.post("/widgets", validate({ body: bodySchema }), (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const res = await request(app).post("/widgets").send({ name: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "Validation failed" });
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details[0]).toMatchObject({ path: ["name"] });
+  });
+
+  it("accepts a valid body with 200", async () => {
+    const bodySchema = z.object({ name: z.string().min(1) });
+    const app = express();
+
+    app.use(express.json());
+    app.post("/widgets", validate({ body: bodySchema }), (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const res = await request(app).post("/widgets").send({ name: "Mona" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("coerces query params and exposes parsed values to handlers", async () => {
+    const querySchema = z.object({ limit: z.coerce.number().int().positive() });
+    const app = express();
+
+    app.get("/search", validate({ query: querySchema }), (req, res) => {
+      const parsedReq = req as unknown as ValidatedRequest<
+        undefined,
+        typeof querySchema
+      >;
+      res.status(200).json({
+        limit: parsedReq.query.limit,
+        limitType: typeof parsedReq.query.limit,
+      });
+    });
+
+    const res = await request(app).get("/search?limit=3");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ limit: 3, limitType: "number" });
+  });
+
+  it("replaces req.body with parsed values", async () => {
+    const bodySchema = z.object({ count: z.coerce.number().int().positive() });
+    const app = express();
+
+    app.use(express.json());
+    app.post("/counts", validate({ body: bodySchema }), (req, res) => {
+      const parsedReq = req as unknown as ValidatedRequest<typeof bodySchema>;
+      res.status(200).json({
+        count: parsedReq.body.count,
+        countType: typeof parsedReq.body.count,
+      });
+    });
+
+    const res = await request(app).post("/counts").send({ count: "7" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ count: 7, countType: "number" });
+  });
+});
+
+describe("GET /users validation", () => {
+  const records: UserRecord[] = [
+    {
+      id: 1,
+      name: "Mona Lisa",
+      email: "mona@example.com",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    },
+    {
+      id: 2,
+      name: "Octo Cat",
+      email: "octo@example.com",
+      createdAt: new Date("2024-01-02T00:00:00.000Z"),
+    },
+    {
+      id: 3,
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      createdAt: new Date("2024-01-03T00:00:00.000Z"),
+    },
+  ];
+
+  const buildUsersApp = () => {
+    let observedOptions: FindManyOptions | undefined;
+    const database = {
+      query: {
+        users: {
+          findMany: async (options: FindManyOptions): Promise<UserRecord[]> => {
+            observedOptions = options;
+            return records.slice(options.offset, options.offset + options.limit);
+          },
+        },
+      },
+    };
+    const app = express();
+
+    app.use(express.json());
+    app.use("/users", createUsersRouter(database));
+
+    return { app, getObservedOptions: () => observedOptions };
+  };
+
+  it("returns 400 with the validation error shape on bad input", async () => {
+    const { app } = buildUsersApp();
+
+    const res = await request(app)
+      .get("/users?limit=0")
+      .set("Authorization", `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "Validation failed" });
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details[0]).toMatchObject({ path: ["limit"] });
+  });
+
+  it("returns at most limit rows and honors offset", async () => {
+    const { app, getObservedOptions } = buildUsersApp();
+
+    const res = await request(app)
+      .get("/users?limit=2&offset=1")
+      .set("Authorization", `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((user: { id: number }) => user.id)).toEqual([2, 3]);
+    expect(getObservedOptions()).toEqual({ limit: 2, offset: 1 });
+  });
+});

--- a/services/platform-api/src/middleware/validate.ts
+++ b/services/platform-api/src/middleware/validate.ts
@@ -1,0 +1,111 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { z, ZodIssue, ZodSchema } from "zod";
+
+type MaybeSchema = ZodSchema<unknown> | undefined;
+type InferSchema<TSchema extends MaybeSchema, TFallback> =
+  TSchema extends ZodSchema<unknown> ? z.infer<TSchema> : TFallback;
+
+type DefaultParams = Record<string, string>;
+type DefaultQuery = Record<string, unknown>;
+
+export type ValidationSchemas<
+  TBodySchema extends MaybeSchema = undefined,
+  TQuerySchema extends MaybeSchema = undefined,
+  TParamsSchema extends MaybeSchema = undefined,
+> = {
+  body?: TBodySchema;
+  query?: TQuerySchema;
+  params?: TParamsSchema;
+};
+
+export type ValidatedRequest<
+  TBodySchema extends MaybeSchema = undefined,
+  TQuerySchema extends MaybeSchema = undefined,
+  TParamsSchema extends MaybeSchema = undefined,
+> = Omit<Request, "body" | "query" | "params"> & {
+  body: InferSchema<TBodySchema, unknown>;
+  query: InferSchema<TQuerySchema, DefaultQuery>;
+  params: InferSchema<TParamsSchema, DefaultParams>;
+};
+
+export type ValidatedRequestHandler<
+  TBodySchema extends MaybeSchema = undefined,
+  TQuerySchema extends MaybeSchema = undefined,
+  TParamsSchema extends MaybeSchema = undefined,
+> = (
+  req: ValidatedRequest<TBodySchema, TQuerySchema, TParamsSchema>,
+  res: Response,
+  next: NextFunction,
+) => unknown;
+
+const replaceRequestPart = (
+  req: object,
+  key: "body" | "query" | "params",
+  value: unknown,
+): void => {
+  Object.defineProperty(req, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+};
+
+const collectIssues = <TSchema extends ZodSchema<unknown>>(
+  schema: TSchema,
+  value: unknown,
+  issues: ZodIssue[],
+): unknown => {
+  const result = schema.safeParse(value);
+
+  if (!result.success) {
+    issues.push(...result.error.issues);
+    return undefined;
+  }
+
+  return result.data;
+};
+
+export function validate<
+  TBodySchema extends MaybeSchema = undefined,
+  TQuerySchema extends MaybeSchema = undefined,
+  TParamsSchema extends MaybeSchema = undefined,
+>(
+  schemas: ValidationSchemas<TBodySchema, TQuerySchema, TParamsSchema>,
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      const issues: ZodIssue[] = [];
+      const parsedBody = schemas.body
+        ? collectIssues(schemas.body, req.body, issues)
+        : undefined;
+      const parsedQuery = schemas.query
+        ? collectIssues(schemas.query, req.query, issues)
+        : undefined;
+      const parsedParams = schemas.params
+        ? collectIssues(schemas.params, req.params, issues)
+        : undefined;
+
+      if (issues.length > 0) {
+        res.status(400).json({ error: "Validation failed", details: issues });
+        return;
+      }
+
+      if (schemas.body) {
+        replaceRequestPart(req, "body", parsedBody);
+      }
+
+      if (schemas.query) {
+        replaceRequestPart(req, "query", parsedQuery);
+      }
+
+      if (schemas.params) {
+        replaceRequestPart(req, "params", parsedParams);
+      }
+
+      next();
+    } catch (error: unknown) {
+      next(error);
+    }
+  };
+}

--- a/services/platform-api/src/routes/__tests__/health.test.ts
+++ b/services/platform-api/src/routes/__tests__/health.test.ts
@@ -15,7 +15,7 @@ function buildAppWithPing(dbPing: () => Promise<void>) {
 
 describe("GET /health", () => {
   it("returns 200 with status: ok and db: up when the DB ping resolves", async () => {
-    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const dbPing = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const app = buildAppWithPing(dbPing);
 
     const res = await request(app).get("/health");
@@ -27,7 +27,7 @@ describe("GET /health", () => {
 
   it("returns 503 with status: degraded when the DB ping rejects", async () => {
     const dbPing = jest
-      .fn()
+      .fn<() => Promise<void>>()
       .mockRejectedValue(new Error("connection refused"));
     const app = buildAppWithPing(dbPing);
 
@@ -42,7 +42,7 @@ describe("GET /health", () => {
   });
 
   it("responds to a trailing slash too", async () => {
-    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const dbPing = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const app = buildAppWithPing(dbPing);
 
     const res = await request(app).get("/health/");
@@ -52,7 +52,7 @@ describe("GET /health", () => {
   });
 
   it("returns JSON content-type", async () => {
-    const dbPing = jest.fn().mockResolvedValue(undefined);
+    const dbPing = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const app = buildAppWithPing(dbPing);
 
     const res = await request(app).get("/health");

--- a/services/platform-api/src/routes/health.ts
+++ b/services/platform-api/src/routes/health.ts
@@ -1,6 +1,8 @@
 import { Router, type Router as RouterType } from "express";
 import { sql } from "drizzle-orm";
 import { db } from "../db/index.js";
+import { validate } from "../middleware/validate.js";
+import { healthParams, healthQuery } from "../validators/health.validators.js";
 
 /**
  * Default implementation: runs a trivial `SELECT 1` against the configured
@@ -12,27 +14,31 @@ export const defaultDbPing = async (): Promise<void> => {
 };
 
 export const createHealthRouter = (
-  dbPing: () => Promise<void> = defaultDbPing
+  dbPing: () => Promise<void> = defaultDbPing,
 ): RouterType => {
   const router = Router();
 
-  router.get("/", async (_req, res) => {
-    try {
-      await dbPing();
-      return res.status(200).json({ status: "ok", db: "up" });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Database health check failed";
-      console.error("Health check DB error:", message);
-      return res
-        .status(503)
-        .json({ status: "degraded", db: "down", error: message });
-    }
-  });
+  router.get(
+    "/",
+    validate({ query: healthQuery, params: healthParams }),
+    async (_req, res) => {
+      try {
+        await dbPing();
+        return res.status(200).json({ status: "ok", db: "up" });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Database health check failed";
+        console.error("Health check DB error:", message);
+        return res
+          .status(503)
+          .json({ status: "degraded", db: "down", error: message });
+      }
+    },
+  );
 
   return router;
 };
 
-const router: Router = createHealthRouter();
+const router: RouterType = createHealthRouter();
 
 export default router;

--- a/services/platform-api/src/routes/users.ts
+++ b/services/platform-api/src/routes/users.ts
@@ -1,19 +1,57 @@
 import { Router, type Router as RouterType } from "express";
 import { db } from "../db/index.js";
+import { users } from "../db/schema.js";
 import { requireBearerToken } from "../middleware/auth.js";
+import { validate, type ValidatedRequest } from "../middleware/validate.js";
+import {
+  listUsersParams,
+  listUsersQuery,
+  type ListUsersQuery,
+} from "../validators/users.validators.js";
 
-const router: RouterType = Router();
+type UserRecord = typeof users.$inferSelect;
 
-router.use(requireBearerToken);
+type UsersDatabase = {
+  query: {
+    users: {
+      findMany: (options: {
+        limit: ListUsersQuery["limit"];
+        offset: ListUsersQuery["offset"];
+      }) => Promise<UserRecord[]>;
+    };
+  };
+};
 
-router.get("/", async (req, res) => {
-  try {
-    const allUsers = await db.query.users.findMany();
-    res.json(allUsers);
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Internal Server Error" });
-  }
-});
+type ListUsersRequest = ValidatedRequest<
+  undefined,
+  typeof listUsersQuery,
+  typeof listUsersParams
+>;
+
+export const createUsersRouter = (database: UsersDatabase = db): RouterType => {
+  const router: RouterType = Router();
+
+  router.use(requireBearerToken);
+
+  router.get(
+    "/",
+    validate({ query: listUsersQuery, params: listUsersParams }),
+    async (req, res) => {
+      try {
+        const parsedReq = req as unknown as ListUsersRequest;
+        const { limit, offset } = parsedReq.query;
+        const allUsers = await database.query.users.findMany({ limit, offset });
+        res.json(allUsers);
+      } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: "Internal Server Error" });
+      }
+    },
+  );
+
+  return router;
+};
+
+const router: RouterType = createUsersRouter();
 
 export default router;

--- a/services/platform-api/src/validators/health.validators.ts
+++ b/services/platform-api/src/validators/health.validators.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const healthQuery = z.object({});
+export const healthParams = z.object({});

--- a/services/platform-api/src/validators/pagination.ts
+++ b/services/platform-api/src/validators/pagination.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const paginationQuery = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  offset: z.coerce.number().int().nonnegative().default(0),
+});
+
+export type PaginationQuery = z.infer<typeof paginationQuery>;

--- a/services/platform-api/src/validators/users.validators.ts
+++ b/services/platform-api/src/validators/users.validators.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { paginationQuery } from "./pagination.js";
+
+export const listUsersQuery = paginationQuery;
+export const listUsersParams = z.object({});
+
+export type ListUsersQuery = z.infer<typeof listUsersQuery>;
+export type ListUsersParams = z.infer<typeof listUsersParams>;


### PR DESCRIPTION
## Problem

Platform API endpoints did not parse request inputs with Zod, and `GET /users` returned every user with no pagination.

## Route inventory

- `GET /health`: no body, query, or path parameters; now wired through empty Zod query/params schemas.
- `GET /users`: no body or path parameters; query now accepts `limit` and `offset` via shared pagination validation.

## Design

- Added `validate()` middleware for Express request `body`, `query`, and `params` schemas.
- Validation failures return a safe 400 response without stack traces.
- Successful parses replace `req.body`, `req.query`, and `req.params` with parsed values.
- Added per-route validators under `src/validators/` plus shared `paginationQuery`.
- `GET /users` now calls Drizzle `findMany({ limit, offset })` and keeps the existing response shape.
- No password/token/secret fields are present in the current user response model, so no response redaction was needed.

## Example validation error

```json
{
  "error": "Validation failed",
  "details": [
    {
      "code": "too_small",
      "minimum": 1,
      "type": "number",
      "inclusive": true,
      "exact": false,
      "message": "Number must be greater than 0",
      "path": ["limit"]
    }
  ]
}
```

## Test summary

- `pnpm --filter platform-api lint` (passes with existing turbo env warnings)
- `pnpm --filter platform-api build`
- `pnpm --filter platform-api test`

Closes #253

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
