### PR TITLE
feat(rigidport): cookie auth + X-API-Key middleware (#254)

### DIFF
--- a/services/rigidport/README.md
+++ b/services/rigidport/README.md
@@ -1,0 +1,14 @@
+# RigidPort
+
+## Authentication
+
+RigidPort uses two authentication modes:
+
+- Razor Pages use cookie authentication. Sign in at `/Auth/Login` with username `admin`; set `RIGIDPORT_ADMIN_PASSWORD` for the password. If unset, development falls back to `admin`.
+- Minimal API routes under `/api/` require an `X-API-Key` header. Set `ALLOWED_API_KEY` to the allowed key. If unset, development falls back to `dev-api-key-change-me`.
+
+Example minimal API call:
+
+```bash
+curl -H "X-API-Key: dev-api-key-change-me" http://localhost:5000/api/shipments/search
+```

--- a/services/rigidport/RigidPort.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/services/rigidport/RigidPort.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -1,9 +1,14 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RigidPort.Web.Data;
 
 namespace RigidPort.Tests.Helpers;
@@ -18,6 +23,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+        builder.UseSetting("ALLOWED_API_KEY", "test-key");
 
         builder.ConfigureServices(services =>
         {
@@ -39,6 +45,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             // Use the in-memory connection with the same SQLite provider
             services.AddDbContext<AppDbContext>((sp, options) =>
                 options.UseSqlite(sp.GetRequiredService<SqliteConnection>()));
+
+            services
+                .AddAuthentication(TestAuthHandler.AuthenticationScheme)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.AuthenticationScheme, _ => { });
         });
     }
 
@@ -53,5 +63,32 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         SeedData.Initialize(db);
 
         return host;
+    }
+}
+
+public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string AuthenticationScheme = "Test";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "test-admin"),
+            new Claim(ClaimTypes.Role, "Admin"),
+        };
+        var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/services/rigidport/RigidPort.Tests/Integration/ApiKeyAuthMiddlewareTests.cs
+++ b/services/rigidport/RigidPort.Tests/Integration/ApiKeyAuthMiddlewareTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using RigidPort.Tests.Helpers;
+
+namespace RigidPort.Tests.Integration;
+
+public class ApiKeyAuthMiddlewareTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public ApiKeyAuthMiddlewareTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GET_ApiWithoutKey_ReturnsUnauthorized()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/dashboard/stats");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("Invalid or missing X-API-Key", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task GET_ApiWithInvalidKey_ReturnsUnauthorized()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "wrong-key");
+
+        var response = await client.GetAsync("/api/dashboard/stats");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("Invalid or missing X-API-Key", await response.Content.ReadAsStringAsync());
+    }
+}

--- a/services/rigidport/RigidPort.Tests/Integration/DashboardApiTests.cs
+++ b/services/rigidport/RigidPort.Tests/Integration/DashboardApiTests.cs
@@ -11,6 +11,7 @@ public class DashboardApiTests : IClassFixture<CustomWebApplicationFactory>
     public DashboardApiTests(CustomWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-API-Key", "test-key");
     }
 
     [Fact]

--- a/services/rigidport/RigidPort.Tests/Integration/ShipmentApiTests.cs
+++ b/services/rigidport/RigidPort.Tests/Integration/ShipmentApiTests.cs
@@ -11,6 +11,7 @@ public class ShipmentApiTests : IClassFixture<CustomWebApplicationFactory>
     public ShipmentApiTests(CustomWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-API-Key", "test-key");
     }
 
     [Fact]

--- a/services/rigidport/RigidPort.Tests/Integration/TrackingApiTests.cs
+++ b/services/rigidport/RigidPort.Tests/Integration/TrackingApiTests.cs
@@ -11,6 +11,7 @@ public class TrackingApiTests : IClassFixture<CustomWebApplicationFactory>
     public TrackingApiTests(CustomWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-API-Key", "test-key");
     }
 
     [Fact]

--- a/services/rigidport/RigidPort.Web/Middleware/ApiKeyAuthMiddleware.cs
+++ b/services/rigidport/RigidPort.Web/Middleware/ApiKeyAuthMiddleware.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace RigidPort.Web.Middleware;
+
+public sealed class ApiKeyAuthMiddleware
+{
+    private const string ApiKeyHeaderName = "X-API-Key";
+    private const string ApiKeySettingName = "ALLOWED_API_KEY";
+    private const string DevelopmentApiKey = "dev-api-key-change-me";
+
+    private readonly RequestDelegate _next;
+    private readonly IConfiguration _configuration;
+
+    public ApiKeyAuthMiddleware(RequestDelegate next, IConfiguration configuration)
+    {
+        _next = next;
+        _configuration = configuration;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var requestPath = context.Request.Path.Value;
+        if (requestPath is null || !requestPath.StartsWith("/api/", StringComparison.OrdinalIgnoreCase))
+        {
+            await _next(context);
+            return;
+        }
+
+        var expectedApiKey = _configuration[ApiKeySettingName];
+        if (string.IsNullOrEmpty(expectedApiKey))
+        {
+            expectedApiKey = DevelopmentApiKey;
+        }
+
+        if (!context.Request.Headers.TryGetValue(ApiKeyHeaderName, out var providedApiKey)
+            || string.IsNullOrEmpty(providedApiKey.ToString())
+            || !ApiKeysMatch(providedApiKey.ToString(), expectedApiKey))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Invalid or missing X-API-Key");
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static bool ApiKeysMatch(string providedApiKey, string expectedApiKey)
+    {
+        var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes(providedApiKey));
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(expectedApiKey));
+
+        return CryptographicOperations.FixedTimeEquals(providedHash, expectedHash);
+    }
+}

--- a/services/rigidport/RigidPort.Web/Pages/Auth/AccessDenied.cshtml
+++ b/services/rigidport/RigidPort.Web/Pages/Auth/AccessDenied.cshtml
@@ -1,0 +1,9 @@
+@page
+@{
+    ViewData["Title"] = "Access denied";
+}
+
+<section class="content-card p-4">
+    <h1 class="h3 text-danger">Access denied</h1>
+    <p class="mb-0">You do not have permission to access this RigidPort resource.</p>
+</section>

--- a/services/rigidport/RigidPort.Web/Pages/Auth/Login.cshtml
+++ b/services/rigidport/RigidPort.Web/Pages/Auth/Login.cshtml
@@ -1,0 +1,42 @@
+@page
+@model RigidPort.Web.Pages.Auth.LoginModel
+@{
+    ViewData["Title"] = "Sign in";
+}
+
+<section class="row justify-content-center">
+    <div class="col-sm-10 col-md-6 col-lg-4">
+        <div class="content-card p-4">
+            <h1 class="h3 mb-3">Sign in</h1>
+            <p class="text-muted mb-4">Use your RigidPort administrator credentials.</p>
+
+            <form method="post">
+                <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
+                <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                <div class="mb-3">
+                    <label asp-for="Input.Username" class="form-label"></label>
+                    <input asp-for="Input.Username" class="form-control" autocomplete="username" autofocus />
+                    <span asp-validation-for="Input.Username" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Input.Password" class="form-label"></label>
+                    <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
+                    <span asp-validation-for="Input.Password" class="text-danger"></span>
+                </div>
+
+                <div class="form-check mb-4">
+                    <input asp-for="Input.RememberMe" class="form-check-input" />
+                    <label asp-for="Input.RememberMe" class="form-check-label"></label>
+                </div>
+
+                <button type="submit" class="btn btn-teal w-100">Sign in</button>
+            </form>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/rigidport/RigidPort.Web/Pages/Auth/Login.cshtml.cs
+++ b/services/rigidport/RigidPort.Web/Pages/Auth/Login.cshtml.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace RigidPort.Web.Pages.Auth;
+
+public class LoginModel : PageModel
+{
+    private const string AdminUsername = "admin";
+    private const string AdminPasswordSettingName = "RIGIDPORT_ADMIN_PASSWORD";
+    private const string DevelopmentAdminPassword = "admin";
+
+    private readonly IConfiguration _configuration;
+
+    public LoginModel(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    [BindProperty]
+    public LoginInput Input { get; set; } = new();
+
+    public string? ReturnUrl { get; private set; }
+
+    public void OnGet(string? returnUrl = null)
+    {
+        ReturnUrl = returnUrl;
+    }
+
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+    {
+        ReturnUrl = returnUrl;
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var expectedPassword = _configuration[AdminPasswordSettingName];
+        if (string.IsNullOrEmpty(expectedPassword))
+        {
+            expectedPassword = DevelopmentAdminPassword;
+        }
+
+        if (!string.Equals(Input.Username, AdminUsername, StringComparison.Ordinal)
+            || !string.Equals(Input.Password, expectedPassword, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError(string.Empty, "Invalid username or password.");
+            return Page();
+        }
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, AdminUsername),
+            new Claim(ClaimTypes.Role, "Admin"),
+        };
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        var principal = new ClaimsPrincipal(identity);
+
+        await HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            principal,
+            new AuthenticationProperties { IsPersistent = Input.RememberMe });
+
+        if (!Url.IsLocalUrl(returnUrl))
+        {
+            return RedirectToPage("/Index");
+        }
+
+        return LocalRedirect(returnUrl);
+    }
+
+    public sealed class LoginInput
+    {
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        [Display(Name = "Remember me")]
+        public bool RememberMe { get; set; }
+    }
+}

--- a/services/rigidport/RigidPort.Web/Pages/Auth/Logout.cshtml
+++ b/services/rigidport/RigidPort.Web/Pages/Auth/Logout.cshtml
@@ -1,0 +1,2 @@
+@page
+@model RigidPort.Web.Pages.Auth.LogoutModel

--- a/services/rigidport/RigidPort.Web/Pages/Auth/Logout.cshtml.cs
+++ b/services/rigidport/RigidPort.Web/Pages/Auth/Logout.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace RigidPort.Web.Pages.Auth;
+
+public class LogoutModel : PageModel
+{
+    public async Task<IActionResult> OnGetAsync()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return RedirectToPage("/Index");
+    }
+}

--- a/services/rigidport/RigidPort.Web/Pages/Shared/_Layout.cshtml
+++ b/services/rigidport/RigidPort.Web/Pages/Shared/_Layout.cshtml
@@ -47,6 +47,15 @@
                     </li>
                 </ul>
                 <div class="d-flex align-items-center">
+                    @if (User.Identity?.IsAuthenticated == true)
+                    {
+                        <span class="text-light small me-2">@User.Identity.Name</span>
+                        <a class="btn btn-outline-light btn-sm me-2" asp-area="" asp-page="/Auth/Logout">Logout</a>
+                    }
+                    else
+                    {
+                        <a class="btn btn-outline-light btn-sm me-2" asp-area="" asp-page="/Auth/Login">Login</a>
+                    }
                     <button id="themeToggle" class="btn btn-outline-light btn-sm me-2" title="Toggle theme">
                         <i class="bi bi-moon-stars"></i>
                     </button>

--- a/services/rigidport/RigidPort.Web/Program.cs
+++ b/services/rigidport/RigidPort.Web/Program.cs
@@ -1,12 +1,31 @@
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using RigidPort.Web.Data;
+using RigidPort.Web.Middleware;
 using RigidPort.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddRazorPages();
+builder.Services.AddRazorPages(options =>
+{
+    options.Conventions.AuthorizeFolder("/");
+    options.Conventions.AllowAnonymousToPage("/Index");
+    options.Conventions.AllowAnonymousToPage("/Privacy");
+    options.Conventions.AllowAnonymousToPage("/Auth/Login");
+    options.Conventions.AllowAnonymousToPage("/Auth/AccessDenied");
+    options.Conventions.AllowAnonymousToPage("/Error");
+});
+
+builder.Services
+    .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(opts =>
+    {
+        opts.LoginPath = "/Auth/Login";
+        opts.LogoutPath = "/Auth/Logout";
+        opts.AccessDeniedPath = "/Auth/AccessDenied";
+    });
 
 // Rate limiting — built-in ASP.NET Core rate limiter (.NET 7+). Fixed-window
 // per-IP limiter that returns 429 with a Retry-After header.
@@ -59,7 +78,9 @@ if (!app.Environment.IsDevelopment())
 app.UseStaticFiles();
 app.UseRouting();
 app.UseRateLimiter();
+app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<ApiKeyAuthMiddleware>();
 
 // Minimal API endpoints for AJAX
 app.MapGet("/api/shipments/search", async (string? q, ShipmentService svc) =>


### PR DESCRIPTION
## Summary

Closes #254

- Adds cookie authentication for RigidPort Razor Pages, including `/Auth/Login`, `/Auth/Logout`, and `/Auth/AccessDenied`.
- Locks down Razor Pages by default while keeping `/Index`, `/Privacy`, `/Auth/Login`, `/Auth/AccessDenied`, and `/Error` anonymous.
- Adds `X-API-Key` middleware for minimal APIs under `/api/` using constant-time key comparison.
- Updates integration tests with a test auth handler and `X-API-Key: test-key` requests.

## Auth modes

### Razor Pages cookie auth

Sign in at `/Auth/Login` with the dev seed user:

```text
username: admin
password: value of RIGIDPORT_ADMIN_PASSWORD, or admin when unset
```

### Minimal API key auth

Minimal APIs under `/api/` require:

```text
X-API-Key: value of ALLOWED_API_KEY, or dev-api-key-change-me when unset
```

Example:

```bash
curl -H "X-API-Key: dev-api-key-change-me" http://localhost:5000/api/shipments/search
```

## Validation

```bash
docker run --rm -v "$PWD":/workspace -w /workspace mcr.microsoft.com/dotnet/sdk:9.0 dotnet build services/rigidport/RigidPort.sln
docker run --rm -v "$PWD":/workspace -w /workspace mcr.microsoft.com/dotnet/sdk:9.0 dotnet test services/rigidport/RigidPort.Tests/RigidPort.Tests.csproj
```

Both passed locally via the .NET 9 SDK container because `dotnet` is not installed on this host.
