### PR TITLE
docs: refresh READMEs after P2/P3 backlog sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ This project demonstrates the transition from "Single Player Vibe Coding" to "Mu
 
 ## Tech Stack
 
-| Layer               | Technology                                        |
-| ------------------- | ------------------------------------------------- |
-| **Package Manager** | pnpm                                              |
-| **Build System**    | Turborepo                                         |
-| **Frontend**        | Next.js 15 (App Router), React 19, Tailwind CSS 4 |
-| **Backend**         | Node.js, Express.js, Drizzle ORM, Zod             |
-| **Database**        | PostgreSQL                                        |
-| **AI Integration**  | GitHub Copilot SDK (`@github/copilot-sdk`)        |
-| **Testing**         | Jest, React Testing Library, @swc/jest            |
+| Layer               | Technology                                                              |
+| ------------------- | ----------------------------------------------------------------------- |
+| **Package Manager** | pnpm 10.x                                                               |
+| **Build System**    | Turborepo                                                               |
+| **Frontend**        | Next.js 15 (App Router), React 19, Tailwind CSS 4                       |
+| **Backend**         | Node.js, Express.js, Hono, Drizzle ORM, Zod 4                           |
+| **Logging**         | pino + pino-http (structured JSON logs in services)                     |
+| **Containers**      | Multi-stage Dockerfiles for `medical-api` & `platform-api`              |
+| **Database**        | PostgreSQL                                                              |
+| **AI Integration**  | GitHub Copilot SDK (`@github/copilot-sdk`)                              |
+| **.NET Service**    | ASP.NET Core 9 (Razor Pages + minimal APIs) — `rigidport`               |
+| **Testing**         | Jest, React Testing Library, @swc/jest, xUnit (.NET)                    |
 
 ## Repository Structure
 
@@ -56,8 +59,10 @@ An AI-powered support ticket portal that converts user-submitted tickets into st
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 8+
+- pnpm 10+ (the repo pins `pnpm@10.26.2` via `packageManager`)
 - PostgreSQL (for apps that require a database)
+- .NET 9 SDK (only required if working on `services/rigidport`)
+- Docker (optional — for building service container images)
 
 ### Installation
 
@@ -118,7 +123,31 @@ This repository was the subject of an end-to-end **vibe-engineering triage** spr
 - **CI security gates that actually fail** — removed silent `continueOnError` in the Azure Pipeline security scan and added a GitHub Actions workflow for the support-app.
 - **Test coverage from zero → real** — backend services and frontend packages now have Jest test suites with happy-path, validation-failure, and auth-failure coverage.
 
-Outstanding **P2 / P3** issues are tracked under their respective milestones.
+### P2 / P3 Backlog Sweep (latest wave)
+
+The P2/P3 backlog has now been driven to zero through a second wave of focused PRs:
+
+| PR | Theme | Closes |
+| --- | --- | --- |
+| [#344](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/344) | Fix duplicated minimal-API block in `rigidport/Program.cs` (CodeQL CS8803) | (hotfix) |
+| [#345](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/345) | PIPA BC research de-identification in `medical-api` | #259 |
+| [#346](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/346) | Production Dockerfile for `medical-api` | #250 |
+| [#347](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/347) | Production Dockerfile for `platform-api` | #251 |
+| [#348](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/348) | Real security alerting in `medical-api` audit middleware | #258 |
+| [#349](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/349) | Zod input validation + `/users` pagination in `platform-api` | #253 |
+| [#350](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/350) | Structured logging with `pino` in `platform-api` | #264 |
+| [#351](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/351) | Cookie auth + `X-API-Key` middleware for `rigidport` | #254 |
+| [#352](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/352) | Workspace-wide Zod 3 → 4 migration | #208 |
+
+**Net effect:**
+
+- All Node services now ship a multi-stage **Dockerfile** with non-root runtime and `pnpm deploy --prod` output.
+- `platform-api` emits **structured JSON logs** via pino with sensitive-field redaction and request-scoped `req.log`.
+- `medical-api` writes audit-trail **security alerts** to an optional `ALERT_WEBHOOK_URL` (or stderr) and **de-identifies research-purpose responses** (drops direct identifiers, generalizes DOB to birth year, postal code to FSA).
+- `rigidport` now requires cookie auth for Razor Pages and `X-API-Key` for minimal APIs; 48/48 xUnit tests pass via a `TestAuthHandler`.
+- The entire workspace is on **Zod 4** (`^4.4.x`) — uniform error handling (`ZodError.issues`), top-level `z.email()` / `z.url()` validators, and consistent schema composition (`.extend()` over `.merge()`).
+
+The current backlog is **0 open issues, 0 open PRs**.
 
 ## Contributing
 

--- a/apps/octocat-blog-app/README.md
+++ b/apps/octocat-blog-app/README.md
@@ -26,7 +26,7 @@ A GitHub-themed blog application built with Next.js 15, shadcn/ui, and PostgreSQ
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 8+
+- pnpm 10+
 - PostgreSQL database
 
 ### Installation

--- a/apps/octocat-support-app/README.md
+++ b/apps/octocat-support-app/README.md
@@ -45,7 +45,7 @@ An AI-powered support ticket portal that converts user-submitted tickets into st
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 8+
+- pnpm 10+
 - A GitHub Personal Access Token (PAT) with `repo` scope
 
 ### Installation

--- a/services/medical-api/README.md
+++ b/services/medical-api/README.md
@@ -15,16 +15,18 @@ This API implements British Columbia's Personal Information Protection Act (PIPA
 | [Hono](https://hono.dev/)                     | 4.4.x   | Lightweight HTTP framework   |
 | [Drizzle ORM](https://orm.drizzle.team/)      | 0.45.x  | Type-safe PostgreSQL ORM     |
 | [PostgreSQL](https://www.postgresql.org/)     | 15+     | Database (via node-postgres) |
-| [Zod](https://zod.dev/)                       | 3.23.x  | Request validation           |
+| [Zod](https://zod.dev/)                       | 4.4.x   | Request validation           |
 | [TypeScript](https://www.typescriptlang.org/) | 5.5.x   | Type safety                  |
+| Docker (multi-stage)                          | —       | Production container image   |
 
 ## Quick Start
 
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 10+
 - PostgreSQL 15+ (local or remote)
+- Docker (optional — to build the production image)
 
 ### Installation
 
@@ -75,6 +77,20 @@ pnpm dev
 # Production
 pnpm build
 pnpm start
+```
+
+### Docker
+
+A multi-stage `Dockerfile` ships with the service (see PR [#346](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/346)). It uses `pnpm deploy --prod` for the runtime layer, runs as a non-root user, and exposes port `3000`:
+
+```bash
+# Build from the repo root (Dockerfile uses the monorepo workspace)
+docker build -t medical-api:local -f services/medical-api/Dockerfile .
+
+# Run (DATABASE_URL is required)
+docker run --rm -p 3000:3000 \
+  -e DATABASE_URL="postgres://user:pass@host:5432/medical_db" \
+  medical-api:local
 ```
 
 ## API Endpoints
@@ -156,6 +172,7 @@ See [PIPA_COMPLIANCE.md](./PIPA_COMPLIANCE.md) for detailed compliance documenta
 | Section 34   | Audit Trail        | `src/middleware/audit.ts` - Log access without PHI values |
 | Section 9    | Consent Withdrawal | DELETE consent endpoint                                   |
 | Section 18   | Emergency Access   | Bypass consent for emergencies                            |
+| Section 35   | Research Use       | De-identification in `src/utils/pii-filter.ts` — drops direct identifiers, generalizes DOB → birth year, postal code → FSA, marks `_deidentified: true` (see PR [#345](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/345)) |
 
 ## Project Structure
 
@@ -179,6 +196,8 @@ services/medical-api/
 │   │   └── pii-filter.ts      # Data minimization helper
 │   └── index.ts               # Hono server entry point
 ├── drizzle.config.ts          # Drizzle Kit configuration
+├── Dockerfile                 # Multi-stage production image (non-root)
+├── .dockerignore
 ├── package.json
 ├── tsconfig.json
 ├── PIPA_COMPLIANCE.md         # Compliance documentation

--- a/services/platform-api/README.md
+++ b/services/platform-api/README.md
@@ -8,9 +8,11 @@
 | ----- | ------- |
 | Framework | [Express 4](https://expressjs.com/) |
 | ORM | [Drizzle](https://orm.drizzle.team/) (PostgreSQL) |
-| Validation | [Zod](https://zod.dev/) |
+| Validation | [Zod 4](https://zod.dev/) — centralized `validate(schema)` middleware + per-route schemas in [`src/validators/`](src/validators/) (PR [#349](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/349)) |
 | Auth | Bearer token (`PLATFORM_API_TOKEN` env) — see [`src/middleware/auth.ts`](src/middleware/auth.ts) |
 | Rate limiting | [`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit) — see PR #290 |
+| Logging | [`pino`](https://getpino.io/) + [`pino-http`](https://github.com/pinojs/pino-http) — structured JSON, sensitive-field redaction, dev-mode `pino-pretty` (PR [#350](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/350)) |
+| Container | Multi-stage [`Dockerfile`](Dockerfile) — non-root runtime, `pnpm deploy --prod` (PR [#347](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/347)) |
 | Tests | Jest + supertest |
 
 ## Endpoints
@@ -18,18 +20,19 @@
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
 | `GET` | `/health` | none | Liveness probe |
-| `GET` | `/users` | none | List users (safe DTO — no password hashes) |
+| `GET` | `/users?page=1&pageSize=20` | none | List users (safe DTO — no password hashes). Paginated; defaults `page=1`, `pageSize=20`, max `pageSize=100`. Response includes `{ data, pagination: { page, pageSize, total, totalPages } }`. |
 | `POST` | `/users` | Bearer | Create a user |
 
-See [`src/routes/`](src/routes/) for full handler source.
+All inputs are validated by Zod schemas in [`src/validators/`](src/validators/) via a centralized `validate(schema)` middleware. See [`src/routes/`](src/routes/) for handler source.
 
 ## Quick start
 
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 10+
 - PostgreSQL 15+
+- Docker (optional — to build the production container image)
 
 ### Environment
 
@@ -53,6 +56,23 @@ pnpm start    # node dist/index.js
 ```
 
 Service listens on **http://localhost:3001** by default (override with `PORT`).
+
+### Docker
+
+```bash
+# Build from the repo root
+docker build -t platform-api:local -f services/platform-api/Dockerfile .
+
+# Run
+docker run --rm -p 3001:3001 \
+  -e DATABASE_URL="postgres://user:pass@host:5432/platform_db" \
+  -e PLATFORM_API_TOKEN="dev-token" \
+  platform-api:local
+```
+
+### Logging
+
+Logs are structured JSON (pino). Override the level with `LOG_LEVEL` (default `info`). In `NODE_ENV !== 'production'` the dev server uses `pino-pretty` for human-readable output. Sensitive fields (`password`, `token`, `apiKey`, `authorization`) are redacted automatically. Inside request handlers use `req.log.info(...)` / `req.log.error(...)` to get a logger scoped to the current request id.
 
 ## Tests
 

--- a/services/rigidport/README.md
+++ b/services/rigidport/README.md
@@ -1,14 +1,50 @@
 # RigidPort
 
+A full-stack ASP.NET Core 9 logistics demo (Razor Pages for the operator UI + minimal-API endpoints for programmatic access). Backed by EF Core (SQLite) with Chart.js dashboards.
+
+## Tech stack
+
+| Layer | Library |
+| ----- | ------- |
+| Framework | ASP.NET Core 9 (Razor Pages + minimal APIs) |
+| ORM | EF Core 9 (SQLite) |
+| Auth | Cookie auth (Razor Pages) + `X-API-Key` middleware (minimal APIs) — PR [#351](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/351) |
+| Rate limiting | Built-in ASP.NET Core rate limiter — PR [#290](https://github.com/VeVarunSharma/contoso-vibe-engineering/pull/290) |
+| Tests | xUnit + `WebApplicationFactory<Program>` |
+
+## Quick start
+
+Prerequisites: .NET 9 SDK.
+
+```bash
+# Build & test
+dotnet build services/rigidport/RigidPort.sln
+dotnet test  services/rigidport/RigidPort.Tests/RigidPort.Tests.csproj
+
+# Run the web app (listens on http://localhost:5000 by default)
+dotnet run --project services/rigidport/RigidPort.Web
+```
+
 ## Authentication
 
 RigidPort uses two authentication modes:
 
-- Razor Pages use cookie authentication. Sign in at `/Auth/Login` with username `admin`; set `RIGIDPORT_ADMIN_PASSWORD` for the password. If unset, development falls back to `admin`.
-- Minimal API routes under `/api/` require an `X-API-Key` header. Set `ALLOWED_API_KEY` to the allowed key. If unset, development falls back to `dev-api-key-change-me`.
+- **Razor Pages** use cookie authentication. Sign in at `/Auth/Login` with username `admin`; set `RIGIDPORT_ADMIN_PASSWORD` for the password. If unset, development falls back to `admin`. Sign out at `/Auth/Logout`; unauthorized access is redirected to `/Auth/AccessDenied`. Anonymous pages: landing (`/`), `/Privacy`, `/Error`, and the auth pages themselves.
+- **Minimal API routes** under `/api/` require an `X-API-Key` header. Set `ALLOWED_API_KEY` to the allowed key. If unset, development falls back to `dev-api-key-change-me`. The middleware uses `CryptographicOperations.FixedTimeEquals` for constant-time comparison.
 
 Example minimal API call:
 
 ```bash
 curl -H "X-API-Key: dev-api-key-change-me" http://localhost:5000/api/shipments/search
 ```
+
+## Environment variables
+
+| Variable | Purpose | Dev default |
+| -------- | ------- | ----------- |
+| `RIGIDPORT_ADMIN_PASSWORD` | Password for the seeded `admin` Razor Pages user | `admin` |
+| `ALLOWED_API_KEY` | Accepted value for the `X-API-Key` header on `/api/*` routes | `dev-api-key-change-me` |
+
+## Tests
+
+`RigidPort.Tests/Helpers/CustomWebApplicationFactory.cs` registers a `TestAuthHandler` so integration tests can call `[Authorize]` endpoints without going through cookie login, and pre-sets `ALLOWED_API_KEY=test-key` so API tests can send `X-API-Key: test-key`. The suite currently runs **48/48** tests green.


### PR DESCRIPTION
## Summary

Sweep of README files to reflect the work shipped in the recent P2/P3 backlog wave (PRs #344–#352). Documentation-only change — no source files touched.

## Files updated

### `README.md` (root)
- **Tech stack table**: added Hono, pino, Dockerfile row, .NET service row, xUnit; updated Zod → 4; pinned pnpm to 10.x.
- **Prerequisites**: pnpm `8+` → `10+` (matches `packageManager: "pnpm@10.26.2"`); added .NET 9 SDK + Docker (optional).
- **New section "P2 / P3 Backlog Sweep (latest wave)"**: table of all 9 recent PRs (#344–#352) with what each closed and a "Net effect" summary covering Dockerfiles, structured logging, security alerting, research de-identification, RigidPort auth, and the Zod 4 migration.
- Notes backlog is now `0 open issues, 0 open PRs`.

### `services/medical-api/README.md`
- Zod version bumped `3.23.x` → `4.4.x` in the tech-stack table.
- Added `Docker` row to the tech-stack table.
- pnpm prereq `9+` → `10+`; added Docker as optional prereq.
- New **Docker** section with build/run commands (uses repo-root build context).
- Added **Section 35 (Research Use)** row to the PIPA compliance table documenting the new `pii-filter.ts` de-identification (drops direct identifiers, generalizes DOB → birth year, postal code → FSA).
- Added `Dockerfile` + `.dockerignore` to the Project Structure tree.

### `services/platform-api/README.md`
- Tech-stack table: Zod row now references the centralized `validate(schema)` middleware + `src/validators/`; new rows for **Logging** (pino + pino-http) and **Container** (Dockerfile).
- `/users` endpoint row now documents the `page` / `pageSize` query params and the `{ data, pagination }` response shape.
- pnpm prereq `9+` → `10+`; added Docker as optional prereq.
- New **Docker** section with build/run commands.
- New **Logging** section explaining `LOG_LEVEL`, dev pino-pretty, sensitive-field redaction, and `req.log` usage.

### `services/rigidport/README.md`
- Expanded from auth-only stub into a full README with overview, tech stack, quick-start (build + test + run), env-var table, and test-suite notes (`TestAuthHandler`, 48/48 green).
- Auth section now explicitly notes anonymous pages and the constant-time API-key compare.

### `apps/octocat-blog-app/README.md` & `apps/octocat-support-app/README.md`
- pnpm prereq `8+` → `10+`.

## Validation

Documentation only — no code changes, no test or lint impact. `git diff --stat`: 6 files, +125 / −21.

Closes the documentation follow-up after the P2/P3 backlog sweep.
