### PR TITLE
Prevent stale AI digest rate-limit buckets from accumulating

### DIFF
--- a/services/ai-tool-digest/src/__tests__/rateLimit.test.ts
+++ b/services/ai-tool-digest/src/__tests__/rateLimit.test.ts
@@ -1,4 +1,9 @@
-import { checkRateLimit, getClientIp, __resetBuckets } from "../rateLimit.js";
+import {
+  checkRateLimit,
+  getClientIp,
+  __getBucketCount,
+  __resetBuckets,
+} from "../rateLimit.js";
 
 describe("rateLimit", () => {
   beforeEach(() => __resetBuckets());
@@ -42,6 +47,28 @@ describe("rateLimit", () => {
       expect(blocked.allowed).toBe(false);
       const otherIp = checkRateLimit("2.2.2.2", 2000);
       expect(otherIp.allowed).toBe(true);
+    });
+
+    it("removes expired one-off client buckets during scheduled cleanup", () => {
+      checkRateLimit("stale-1", 1000);
+      checkRateLimit("stale-2", 1000);
+      expect(__getBucketCount()).toBe(2);
+
+      checkRateLimit("cleanup-trigger", 61_000);
+
+      expect(__getBucketCount()).toBe(1);
+    });
+
+    it("retains active client counts when expired buckets are cleaned up", () => {
+      checkRateLimit("stale", 1000);
+      checkRateLimit("active", 30_000);
+      checkRateLimit("active", 30_001);
+
+      checkRateLimit("cleanup-trigger", 61_000);
+      const active = checkRateLimit("active", 61_001);
+
+      expect(active.remaining).toBe(27);
+      expect(__getBucketCount()).toBe(2);
     });
 
     it("falls back to 'unknown' when key is empty", () => {

--- a/services/ai-tool-digest/src/rateLimit.ts
+++ b/services/ai-tool-digest/src/rateLimit.ts
@@ -19,6 +19,22 @@ const WINDOW_MS = 60 * 1000;
 const LIMIT = 30;
 
 const buckets = new Map<string, Bucket>();
+// Sweep on the request path at most once per window to avoid background timers.
+let nextCleanupAt = 0;
+
+function removeExpiredBuckets(now: number): void {
+  if (now < nextCleanupAt) {
+    return;
+  }
+
+  for (const [key, bucket] of buckets) {
+    if (now >= bucket.resetAt) {
+      buckets.delete(key);
+    }
+  }
+
+  nextCleanupAt = now + WINDOW_MS;
+}
 
 export interface RateLimitResult {
   allowed: boolean;
@@ -33,6 +49,8 @@ export function checkRateLimit(
   if (!key) {
     key = "unknown";
   }
+
+  removeExpiredBuckets(now);
 
   const existing = buckets.get(key);
   if (!existing || now >= existing.resetAt) {
@@ -68,4 +86,9 @@ export function getClientIp(request: { headers: HeaderReader }): string {
 
 export function __resetBuckets(): void {
   buckets.clear();
+  nextCleanupAt = 0;
+}
+
+export function __getBucketCount(): number {
+  return buckets.size;
 }


### PR DESCRIPTION
## Summary
- sweep expired in-memory rate-limit buckets on the request path at most once per 60-second window
- preserve the existing 30 requests per 60 seconds behavior and forwarded client IP handling
- add focused Jest coverage for stale-key removal and active-client continuity during cleanup

## Validation
- `pnpm --filter ai-tool-digest test -- --runInBand rateLimit.test.ts` (12 tests passed)
- `pnpm --filter ai-tool-digest test -- --runInBand` (37 tests passed)
- `pnpm --filter ai-tool-digest build`
- `pnpm --filter ai-tool-digest lint` (0 errors; 6 pre-existing `turbo/no-undeclared-env-vars` warnings in `config.test.ts`)