### PR TITLE
Make PR merge transitions deterministic

### DIFF
--- a/.github/workflows/pr-merge-assistant.lock.yml
+++ b/.github/workflows/pr-merge-assistant.lock.yml
@@ -23,7 +23,7 @@
 #
 # Automatically reviews, repairs, and merges one open pull request at a time.
 #
-# frontmatter-hash: b4ee4a5c88341e7a0fdf3d12527ac0c9727294d437bc75b0e6d8cd170a0117c3
+# frontmatter-hash: 734a8142be3ca9fd0dc3de3b6f887a125197bfa2945300382b9611bca67e2473
 
 name: "PR Merge Assistant"
 "on":
@@ -114,7 +114,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         name: Prefetch oldest open PR
-        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/agent\n\ngh pr list \\\n  --repo \"$REPO\" \\\n  --state open \\\n  --limit 100 \\\n  --json number,title,isDraft,createdAt \\\n  --jq 'sort_by(.createdAt) | map(select(.isDraft == false)) | .[0] // {}' \\\n  > /tmp/gh-aw/agent/selected-pr.json\n\nPR_NUMBER=$(jq -r '.number // empty' /tmp/gh-aw/agent/selected-pr.json)\nif [[ -z \"$PR_NUMBER\" ]]; then\n  printf '{}\\n' > /tmp/gh-aw/agent/pr-state.json\n  printf '{\"reviewThreads\":[]}\\n' > /tmp/gh-aw/agent/review-threads.json\n  printf '[]\\n' > /tmp/gh-aw/agent/review-events.json\n  exit 0\nfi\n\ngh pr view \"$PR_NUMBER\" \\\n  --repo \"$REPO\" \\\n  --json number,title,url,author,assignees,isDraft,createdAt,updatedAt,baseRefName,headRefName,mergeStateStatus,reviewDecision,reviewRequests,reviews,commits,comments,labels,statusCheckRollup \\\n  > /tmp/gh-aw/agent/pr-state.json\n\nOWNER=${REPO%%/*}\nNAME=${REPO#*/}\ngh api graphql \\\n  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(first:20){nodes{author{login}body createdAt url}}}}}}}' \\\n  -f owner=\"$OWNER\" \\\n  -f name=\"$NAME\" \\\n  -F number=\"$PR_NUMBER\" \\\n  --jq '.data.repository.pullRequest.reviewThreads' \\\n  > /tmp/gh-aw/agent/review-threads.json\n\ngh api \\\n  \"repos/$REPO/issues/$PR_NUMBER/timeline?per_page=100\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  --jq '[.[]\n    | select(.event == \"review_requested\" or .event == \"review_request_removed\")\n    | {\n        event,\n        created_at,\n        actor: .actor.login,\n        requested_reviewer: .requested_reviewer.login\n      }\n  ]' \\\n  > /tmp/gh-aw/agent/review-events.json\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/agent\n\ngh pr list \\\n  --repo \"$REPO\" \\\n  --state open \\\n  --limit 100 \\\n  --json number,title,isDraft,createdAt \\\n  --jq 'sort_by(.createdAt) | map(select(.isDraft == false)) | .[0] // {}' \\\n  > /tmp/gh-aw/agent/selected-pr.json\n\nPR_NUMBER=$(jq -r '.number // empty' /tmp/gh-aw/agent/selected-pr.json)\nif [[ -z \"$PR_NUMBER\" ]]; then\n  printf '{}\\n' > /tmp/gh-aw/agent/pr-state.json\n  printf '{\"reviewThreads\":[]}\\n' > /tmp/gh-aw/agent/review-threads.json\n  printf '[]\\n' > /tmp/gh-aw/agent/review-events.json\n  printf '{\"action\":\"none\",\"reason\":\"No open non-draft pull requests.\"}\\n' > /tmp/gh-aw/agent/decision-state.json\n  exit 0\nfi\n\ngh pr view \"$PR_NUMBER\" \\\n  --repo \"$REPO\" \\\n  --json number,title,url,author,assignees,isDraft,createdAt,updatedAt,baseRefName,headRefName,mergeStateStatus,reviewDecision,reviewRequests,reviews,commits,comments,labels,statusCheckRollup \\\n  > /tmp/gh-aw/agent/pr-state.json\n\nOWNER=${REPO%%/*}\nNAME=${REPO#*/}\ngh api graphql \\\n  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(first:20){nodes{author{login}body createdAt url}}}}}}}' \\\n  -f owner=\"$OWNER\" \\\n  -f name=\"$NAME\" \\\n  -F number=\"$PR_NUMBER\" \\\n  --jq '.data.repository.pullRequest.reviewThreads' \\\n  > /tmp/gh-aw/agent/review-threads.json\n\ngh api \\\n  \"repos/$REPO/issues/$PR_NUMBER/timeline?per_page=100\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  --jq '[.[]\n    | select(.event == \"review_requested\" or .event == \"review_request_removed\")\n    | {\n        event,\n        created_at,\n        actor: .actor.login,\n        requested_reviewer: .requested_reviewer.login\n      }\n  ]' \\\n  > /tmp/gh-aw/agent/review-events.json\n\njq -n \\\n  --slurpfile pr /tmp/gh-aw/agent/pr-state.json \\\n  --slurpfile threads /tmp/gh-aw/agent/review-threads.json \\\n  --slurpfile events /tmp/gh-aw/agent/review-events.json \\\n  '\n    $pr[0] as $p\n    | ($threads[0].nodes // []) as $review_threads\n    | ($events[0] // []) as $review_events\n    | ([ $p.commits[].committedDate ] | max // \"\") as $latest_commit\n    | ([ $p.reviews[]\n          | select(.author.login | startswith(\"copilot-pull-request-reviewer\"))\n          | .submittedAt\n       ] | max // \"\") as $latest_copilot_review\n    | ([ $review_events[]\n          | select((.requested_reviewer // \"\") == \"Copilot\")\n       ] | sort_by(.created_at) | last // {}) as $latest_copilot_event\n    | ([ $review_threads[] | select(.isResolved == false) ] | length) as $unresolved_threads\n    | ([ $p.statusCheckRollup[]\n          | select(\n              (.__typename == \"CheckRun\"\n                and .status == \"COMPLETED\"\n                and (.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\"))\n              or (.__typename == \"StatusContext\" and .state != \"SUCCESS\" and .state != \"PENDING\")\n              or (.__typename != \"CheckRun\" and .__typename != \"StatusContext\")\n            )\n       ] | length) as $failing_checks\n    | ([ $p.statusCheckRollup[]\n          | select(\n              (.__typename == \"CheckRun\" and .status != \"COMPLETED\")\n              or (.__typename == \"StatusContext\" and .state == \"PENDING\")\n            )\n       ] | length) as $pending_checks\n    | any($p.assignees[]?; ((.login // \"\") | ascii_downcase | contains(\"copilot\"))) as $copilot_assigned\n    | ($latest_copilot_review != \"\" and $latest_copilot_review >= $latest_commit) as $review_current\n    | (($latest_copilot_event.event // \"\") == \"review_requested\"\n        and ($latest_copilot_event.created_at // \"\") >= $latest_commit\n        and ($latest_copilot_event.created_at // \"\") > $latest_copilot_review) as $review_pending\n    | {\n        pull_request_number: $p.number,\n        latest_commit: $latest_commit,\n        latest_copilot_review: $latest_copilot_review,\n        review_current: $review_current,\n        review_pending: $review_pending,\n        unresolved_threads: $unresolved_threads,\n        failing_checks: $failing_checks,\n        pending_checks: $pending_checks,\n        review_decision: $p.reviewDecision,\n        copilot_assigned: $copilot_assigned,\n        action:\n          if $review_current == false then\n            if $review_pending then \"wait\" else \"request_review\" end\n          elif ($unresolved_threads > 0 or $failing_checks > 0 or $p.reviewDecision == \"CHANGES_REQUESTED\") then\n            if $copilot_assigned then \"wait\" else \"assign_agent\" end\n          elif $pending_checks > 0 then\n            \"wait\"\n          else\n            \"merge\"\n          end\n      }\n  ' > /tmp/gh-aw/agent/decision-state.json\n"
 
       - name: Configure Git credentials
         env:
@@ -1159,7 +1159,7 @@ jobs:
             --repo "$REPO" \
             --json isDraft,reviewDecision,statusCheckRollup,reviews,commits)
 
-          jq -e '
+          if ! jq -e '
             . as $pr
             | ([ $pr.commits[].committedDate ] | max // "") as $latest_commit
             | ([ $pr.reviews[]
@@ -1181,7 +1181,10 @@ jobs:
                 false
               end
             )
-          ' <<< "$PR_STATE" > /dev/null
+          ' <<< "$PR_STATE" > /dev/null; then
+            echo "::warning::PR #$PR_NUMBER changed after evaluation and no longer satisfies merge gates; deferring to the next run."
+            exit 0
+          fi
 
           OWNER=${REPO%%/*}
           NAME=${REPO#*/}
@@ -1193,8 +1196,8 @@ jobs:
             --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
 
           if [[ "$UNRESOLVED_THREADS" != "0" ]]; then
-            echo "PR #$PR_NUMBER still has $UNRESOLVED_THREADS unresolved review thread(s)." >&2
-            exit 1
+            echo "::warning::PR #$PR_NUMBER now has $UNRESOLVED_THREADS unresolved review thread(s); deferring to the next run."
+            exit 0
           fi
 
           gh pr merge "$PR_NUMBER" --repo "$REPO" --squash
@@ -1342,7 +1345,7 @@ jobs:
           GH_AW_AGENT_TARGET: "*"
           GH_AW_AGENT_ALLOWED: "copilot"
         with:
-          github-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PR_MERGE_AUTOMATION_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);

--- a/.github/workflows/pr-merge-assistant.md
+++ b/.github/workflows/pr-merge-assistant.md
@@ -40,6 +40,7 @@ steps:
         printf '{}\n' > /tmp/gh-aw/agent/pr-state.json
         printf '{"reviewThreads":[]}\n' > /tmp/gh-aw/agent/review-threads.json
         printf '[]\n' > /tmp/gh-aw/agent/review-events.json
+        printf '{"action":"none","reason":"No open non-draft pull requests."}\n' > /tmp/gh-aw/agent/decision-state.json
         exit 0
       fi
 
@@ -71,6 +72,67 @@ steps:
             }
         ]' \
         > /tmp/gh-aw/agent/review-events.json
+
+      jq -n \
+        --slurpfile pr /tmp/gh-aw/agent/pr-state.json \
+        --slurpfile threads /tmp/gh-aw/agent/review-threads.json \
+        --slurpfile events /tmp/gh-aw/agent/review-events.json \
+        '
+          $pr[0] as $p
+          | ($threads[0].nodes // []) as $review_threads
+          | ($events[0] // []) as $review_events
+          | ([ $p.commits[].committedDate ] | max // "") as $latest_commit
+          | ([ $p.reviews[]
+                | select(.author.login | startswith("copilot-pull-request-reviewer"))
+                | .submittedAt
+             ] | max // "") as $latest_copilot_review
+          | ([ $review_events[]
+                | select((.requested_reviewer // "") == "Copilot")
+             ] | sort_by(.created_at) | last // {}) as $latest_copilot_event
+          | ([ $review_threads[] | select(.isResolved == false) ] | length) as $unresolved_threads
+          | ([ $p.statusCheckRollup[]
+                | select(
+                    (.__typename == "CheckRun"
+                      and .status == "COMPLETED"
+                      and (.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED"))
+                    or (.__typename == "StatusContext" and .state != "SUCCESS" and .state != "PENDING")
+                    or (.__typename != "CheckRun" and .__typename != "StatusContext")
+                  )
+             ] | length) as $failing_checks
+          | ([ $p.statusCheckRollup[]
+                | select(
+                    (.__typename == "CheckRun" and .status != "COMPLETED")
+                    or (.__typename == "StatusContext" and .state == "PENDING")
+                  )
+             ] | length) as $pending_checks
+          | any($p.assignees[]?; ((.login // "") | ascii_downcase | contains("copilot"))) as $copilot_assigned
+          | ($latest_copilot_review != "" and $latest_copilot_review >= $latest_commit) as $review_current
+          | (($latest_copilot_event.event // "") == "review_requested"
+              and ($latest_copilot_event.created_at // "") >= $latest_commit
+              and ($latest_copilot_event.created_at // "") > $latest_copilot_review) as $review_pending
+          | {
+              pull_request_number: $p.number,
+              latest_commit: $latest_commit,
+              latest_copilot_review: $latest_copilot_review,
+              review_current: $review_current,
+              review_pending: $review_pending,
+              unresolved_threads: $unresolved_threads,
+              failing_checks: $failing_checks,
+              pending_checks: $pending_checks,
+              review_decision: $p.reviewDecision,
+              copilot_assigned: $copilot_assigned,
+              action:
+                if $review_current == false then
+                  if $review_pending then "wait" else "request_review" end
+                elif ($unresolved_threads > 0 or $failing_checks > 0 or $p.reviewDecision == "CHANGES_REQUESTED") then
+                  if $copilot_assigned then "wait" else "assign_agent" end
+                elif $pending_checks > 0 then
+                  "wait"
+                else
+                  "merge"
+                end
+            }
+        ' > /tmp/gh-aw/agent/decision-state.json
 safe-outputs:
   add-comment:
     max: 1
@@ -89,7 +151,7 @@ safe-outputs:
     allowed: [copilot]
     target: "*"
     max: 1
-    github-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    github-token: ${{ secrets.PR_MERGE_AUTOMATION_TOKEN }}
   noop:
     report-as-issue: false
   missing-data:
@@ -168,7 +230,7 @@ safe-outputs:
               --repo "$REPO" \
               --json isDraft,reviewDecision,statusCheckRollup,reviews,commits)
 
-            jq -e '
+            if ! jq -e '
               . as $pr
               | ([ $pr.commits[].committedDate ] | max // "") as $latest_commit
               | ([ $pr.reviews[]
@@ -190,7 +252,10 @@ safe-outputs:
                   false
                 end
               )
-            ' <<< "$PR_STATE" > /dev/null
+            ' <<< "$PR_STATE" > /dev/null; then
+              echo "::warning::PR #$PR_NUMBER changed after evaluation and no longer satisfies merge gates; deferring to the next run."
+              exit 0
+            fi
 
             OWNER=${REPO%%/*}
             NAME=${REPO#*/}
@@ -202,8 +267,8 @@ safe-outputs:
               --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
 
             if [[ "$UNRESOLVED_THREADS" != "0" ]]; then
-              echo "PR #$PR_NUMBER still has $UNRESOLVED_THREADS unresolved review thread(s)." >&2
-              exit 1
+              echo "::warning::PR #$PR_NUMBER now has $UNRESOLVED_THREADS unresolved review thread(s); deferring to the next run."
+              exit 0
             fi
 
             gh pr merge "$PR_NUMBER" --repo "$REPO" --squash
@@ -226,30 +291,25 @@ Read:
 - `/tmp/gh-aw/agent/pr-state.json`
 - `/tmp/gh-aw/agent/review-threads.json`
 - `/tmp/gh-aw/agent/review-events.json`
+- `/tmp/gh-aw/agent/decision-state.json`
 
-The deterministic prefetch step has selected the oldest non-draft open PR. Never switch to another PR during this run. If `selected-pr.json` has no `number`, call `noop`.
+The deterministic prefetch step has selected the oldest non-draft open PR and computed its next transition. Never switch to another PR during this run. Treat `decision-state.json` as authoritative and do not override its `action`.
 
 ### Step 1: Ensure Copilot code review
 
-Inspect `reviews` in `pr-state.json` and the request/removal timeline in `review-events.json`.
+Follow the `action` in `decision-state.json` exactly:
 
-- Treat Copilot review as pending when the latest event for requested reviewer `Copilot` is `review_requested`, it follows the newest commit, and no newer Copilot review has been submitted. A later `review_request_removed` event cancels the pending state.
-- Never infer a pending request from labels, comments, or the `reviewRequests` field; GitHub does not expose the Copilot bot there.
-- If there is no current Copilot review and Copilot is not already requested, call `request_copilot_review` with `pr_number`. That atomic job requests the reviewer, updates labels, and posts the status comment; do not emit separate comment or label outputs for this transition.
-- If Copilot review is already pending, call `noop`; do not request it again or add another comment.
+- `request_review`: call `request_copilot_review` with `pr_number`. That atomic job requests the reviewer, updates labels, and posts the status comment; do not emit separate comment or label outputs.
+- `wait`: call `noop` with the state values that explain what is pending. Do not add comments or labels.
+- `none`: call `noop` because no eligible PR exists.
 
 ### Step 2: Address feedback or failing checks
 
-Inspect the latest review state, unresolved threads, commit timestamps, assignees, and `statusCheckRollup`.
-
-- If review feedback remains unresolved or a completed check failed, call `assign_to_agent` for this PR unless Copilot is already assigned. Add `changes-requested`, remove `ready-to-merge`, and leave one concise blocker comment.
-- If Copilot is already assigned, call `noop` and wait for its commit.
-- If the latest Copilot review predates the newest commit, call `request_copilot_review` unless a review is already pending.
-- If checks are pending or queued, call `noop` and wait.
+When `action` is `assign_agent`, call `assign_to_agent` for this PR, add `changes-requested`, remove `ready-to-merge`, and leave one concise blocker comment using the counts in `decision-state.json`.
 
 ### Step 3: Merge only after greenlight
 
-Call `merge_pr` with the selected PR number only when all conditions are true:
+When `action` is `merge`, call `merge_pr` with the selected PR number. The computed state guarantees:
 
 1. A Copilot code review was submitted after the newest commit.
 2. `reviewDecision` is not `CHANGES_REQUESTED`.


### PR DESCRIPTION
## Summary

- Computes one authoritative transition: request_review, wait, assign_agent, or merge
- Routes unresolved CCR threads or failing checks to Copilot coding agent
- Uses the dedicated automation token for assignment
- Makes late merge-gate changes defer successfully instead of failing the workflow

## Live-run evidence

CCR completed on the selected PR with one unresolved thread. The prior agent chose merge, and the deterministic final gate correctly blocked it. This change moves that decision into normalized prefetch state so the next action is assign_agent.

## Validation

- gh aw compile succeeds with zero errors and warnings