### PR TITLE
Wire up monorepo test/typecheck commands agents are told to run

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,38 @@ This repository contains frontend applications, shared packages, and backend mic
 - **Database**: PostgreSQL.
 - **Testing**: Jest, React Testing Library, @swc/jest.
 
+## Build, Test & Validation Commands
+
+Run these from the **monorepo root** (they orchestrate every workspace package via Turborepo):
+
+| Command          | What it does                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `pnpm install`   | Install all dependencies (always run from the root, never a subdir) |
+| `pnpm lint`      | Lint every app, package, and service                               |
+| `pnpm typecheck` | Type-check every workspace package (`tsc --noEmit`)                 |
+| `pnpm test`      | Run the Jest suites across the monorepo                            |
+| `pnpm build`     | Build all apps and packages                                        |
+
+**Scope to a single package for faster, targeted validation** (prefer this while iterating):
+
+```bash
+pnpm --filter octocat-support-app test        # one app's tests
+pnpm --filter platform-api typecheck          # one service's type check
+pnpm --filter octocat-blog-app lint           # one app's lint
+```
+
+Notes for agents:
+
+- **Validate the narrowest scope that covers your change first** (`pnpm --filter <pkg> ...`),
+  then run the root command only if the change spans packages.
+- Frontend apps are built by Turborepo; **services in `services/*` are deployed independently
+  and are *not* part of the turbo `build` pipeline**, but they *are* covered by root
+  `lint`, `typecheck`, and `test`.
+- Package/app names for `--filter` match the `name` field in each `package.json`
+  (e.g. `contoso-web-app`, `octocat-blog-app`, `octocat-support-app`, `platform-api`,
+  `medical-api`, `ai-tool-digest`, `@workspace/ui`).
+
+
 ## Rule 1: Architecture & Monorepo
 
 - **ALWAYS** use the workspace protocol for internal dependencies (e.g., `"@workspace/ui": "workspace:*"`).
@@ -57,7 +89,9 @@ This repository contains frontend applications, shared packages, and backend mic
   - `src/db/__tests__/` - Database schema tests (next to schema files)
   - `config/jest/__mocks__/` - Shared mock implementations
 - **ALWAYS** import shared mocks using the `@test-mocks/` alias (e.g., `@test-mocks/db`).
-- **ALWAYS** run `pnpm test` before submitting pull requests.
+- **ALWAYS** validate before submitting a PR: run the targeted `pnpm --filter <package> test`
+  (and `typecheck`/`lint`) for the packages you changed, then `pnpm test` from the root if the
+  change spans multiple packages. See **Build, Test & Validation Commands** above.
 - **NEVER** commit code that breaks existing tests.
 
 ## Rule 5: General Best Practices

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ pnpm dev
 | `pnpm dev`   | Start all apps in development mode |
 | `pnpm build` | Build all apps and packages        |
 | `pnpm lint`  | Run linting across the monorepo    |
+| `pnpm typecheck` | Type-check the whole monorepo  |
 | `pnpm test`  | Run tests across the monorepo      |
 
 ### Dev Servers

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
+    "typecheck": "turbo typecheck",
+    "test": "turbo test",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/services/ai-tool-digest/package.json
+++ b/services/ai-tool-digest/package.json
@@ -9,6 +9,7 @@
     "start": "npm run build && func start",
     "start:watch": "func start",
     "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {

--- a/services/medical-api/package.json
+++ b/services/medical-api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/db/seed.ts",

--- a/services/platform-api/package.json
+++ b/services/platform-api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/db/seed.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -11,8 +11,12 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
-    "check-types": {
-      "dependsOn": ["^check-types"]
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Problem

The repo's agent guidance repeatedly tells coding agents (and human contributors) to validate work with monorepo‑level commands that **did not exist**, which is a top source of unreliable, repetitive agent behavior:

- `.github/copilot-instructions.md` Rule 4: "**ALWAYS** run `pnpm test` before submitting pull requests."
- `README.md` documents `pnpm test` as "Run tests across the monorepo" and Contributing says "Run `pnpm lint` and `pnpm test`".
- `.github/agents/debugger.agent.md` and `dependency-updater.agent.md` instruct running `pnpm test`.

But the **root `package.json`** only defined `build`, `dev`, `lint`, `format` — **no `test` and no `typecheck`**. `turbo.json`'s `check-types` task was **inert** (no package defines a `check-types` script; the three Next.js apps use `typecheck`, services had none). Result:

- `pnpm test` at the root → fails (missing script).
- `turbo check-types` → runs nothing (name mismatch).

CI only worked because each workflow `cd`s into a single package and runs the per‑package script — an agent never got that orchestration.

## Changes

- **`turbo.json`** — rename the dead `check-types` task to `typecheck` (matches the apps + CI + `tsc --noEmit` convention) and add a `test` task.
- **Root `package.json`** — add `test` (`turbo test`) and `typecheck` (`turbo typecheck`) so the commands agents are told to run actually orchestrate across all workspace packages.
- **Services** (`platform-api`, `medical-api`, `ai-tool-digest`) — add a `tsc --noEmit` `typecheck` script so backend is covered by the root command too (previously frontend‑only).
- **`.github/copilot-instructions.md`** — add a concise **Build, Test & Validation Commands** section (root commands + `pnpm --filter` scoping + the note that `services/*` are outside the turbo *build* pipeline but covered by root lint/typecheck/test); point Rule 4 at targeted validation.
- **`README.md`** — document the now‑real `pnpm typecheck`.

## Why this helps agents

- The single most‑repeated validation instruction now works instead of failing → less trial‑and‑error.
- Agents get an explicit, discoverable command surface and a targeted `--filter` pattern for narrow, faster validation.
- `typecheck` is now a real, monorepo‑wide gate covering backend services.

## Compatibility / scope

- **No** hand‑edits to the APM‑generated `AGENTS.md`/`CLAUDE.md`; only the hand‑authored Copilot instruction file was touched.
- No application/runtime or dependency changes; no lockfile churn. CI workflows are untouched (they already `cd` into packages); the new root scripts are strictly additive.
- The `check-types` → `typecheck` rename is grep‑verified: nothing invoked `check-types`.

## Validation

- `pnpm install`
- `pnpm turbo run test --dry-run` and `pnpm turbo run typecheck --dry-run` — both task graphs resolve across every workspace package with no config errors.
- `pnpm --filter platform-api typecheck`, `pnpm --filter @contoso/medical-api typecheck`, `pnpm --filter ai-tool-digest typecheck` — all pass (exit 0), proving the newly added service scripts execute cleanly.